### PR TITLE
[v2-a138] Add missing `VarRef` class and `Gui` subclasses

### DIFF
--- a/syntaxes/ahk2.tmLanguage.json
+++ b/syntaxes/ahk2.tmLanguage.json
@@ -811,11 +811,21 @@
       "patterns": [
         {
           "name": "support.class.ahk2",
-          "match": "(?<!\\.)\\b(?i:Any|Array|BoundFunc|Buffer|Class|ClipboardAll|Closure|ComObjArray|ComObject|ComValue|ComValueRef|Enumerator|Error|File|Float|Func|Gui|IndexError|InputHook|Integer|KeyError|Map|MemberError|MemoryError|Menu|MenuBar|MethodError|Number|Object|OSError|Primitive|PropertyError|RegExMatchInfo|String|TargetError|TimeoutError|TypeError|ValueError|VarRef|ZeroDivisionError)\\b"
+          "match": "(?<!\\.)\\b(?i:Any|Array|BoundFunc|Buffer|Class|ClipboardAll|Closure|ComObjArray|ComObject|ComValue|ComValueRef|Enumerator|Error|File|Float|Func|Gui(?!\\.)|IndexError|InputHook|Integer|KeyError|Map|MemberError|MemoryError|Menu|MenuBar|MethodError|Number|Object|OSError|Primitive|PropertyError|RegExMatchInfo|String|TargetError|TimeoutError|TypeError|ValueError|VarRef|ZeroDivisionError)\\b"
         },
         {
-          "name": "support.class.ahk2",
-          "match": "(?<=Gui\\.)\\b(?i:ActiveX|Button|CheckBox|ComboBox|Control|Custom|DateTime|DDL|Edit|GroupBox|Hotkey|Link|List|ListBox|ListView|MonthCal|Pic|Progress|Radio|Slider|StatusBar|Tab|Text|TreeView|UpDown)\\b"
+          "match": "(?<!\\.)\\b(?i:(Gui)\\b(\\.)\\b(ActiveX|Button|CheckBox|ComboBox|Control|Custom|DateTime|DDL|Edit|GroupBox|Hotkey|Link|List|ListBox|ListView|MonthCal|Pic|Progress|Radio|Slider|StatusBar|Tab|Text|TreeView|UpDown))\\b",
+          "captures": {
+            "1": {
+              "name": "support.class.ahk2"
+            },
+            "2": {
+              "name": "punctuation.accessor.ahk2"
+            },
+            "3": {
+              "name": "support.class.guicontrol.ahk2"
+            }
+          }
         }
       ]
     },

--- a/syntaxes/ahk2.tmLanguage.json
+++ b/syntaxes/ahk2.tmLanguage.json
@@ -808,8 +808,16 @@
       ]
     },
     "default_classes": {
-      "name": "support.class.ahk2",
-      "match": "(?<!\\.)\\b(?i:any|array|boundfunc|buffer|class|clipboardall|closure|comobjarray|comobject|comvalue|comvalueref|enumerator|error|file|float|func|gui|indexerror|inputhook|integer|keyerror|map|membererror|memoryerror|menu|menubar|methoderror|number|object|oserror|primitive|propertyerror|regexmatchinfo|string|targeterror|timeouterror|typeerror|valueerror|zerodivisionerror)\\b"
+      "patterns": [
+        {
+          "name": "support.class.ahk2",
+          "match": "(?<!\\.)\\b(?i:Any|Array|BoundFunc|Buffer|Class|ClipboardAll|Closure|ComObjArray|ComObject|ComValue|ComValueRef|Enumerator|Error|File|Float|Func|Gui|IndexError|InputHook|Integer|KeyError|Map|MemberError|MemoryError|Menu|MenuBar|MethodError|Number|Object|OSError|Primitive|PropertyError|RegExMatchInfo|String|TargetError|TimeoutError|TypeError|ValueError|VarRef|ZeroDivisionError)\\b"
+        },
+        {
+          "name": "support.class.ahk2",
+          "match": "(?<=Gui\\.)\\b(?i:ActiveX|Button|CheckBox|ComboBox|Control|Custom|DateTime|DDL|Edit|GroupBox|Hotkey|Link|List|ListBox|ListView|MonthCal|Pic|Progress|Radio|Slider|StatusBar|Tab|Text|TreeView|UpDown)\\b"
+        }
+      ]
     },
     "default_statement": {
       "name": "meta.conditional.case.ahk2",


### PR DESCRIPTION
<details>
<summary>Built-in Classes</summary>

```ahk
Any
Array
BoundFunc
Buffer 
Class
ClipboardAll
Closure
ComObjArray
ComObject
ComValue 
ComValueRef
Enumerator
Error 
File
Float
Func
Gui
Gui.ActiveX
Gui.Button
Gui.CheckBox
Gui.ComboBox
Gui.Control 
Gui.Custom
Gui.DateTime
Gui.DDL
Gui.Edit
Gui.GroupBox
Gui.Hotkey
Gui.Link
Gui.List
Gui.ListBox
Gui.ListView
Gui.MonthCal
Gui.Pic
Gui.Progress
Gui.Radio
Gui.Slider
Gui.StatusBar
Gui.Tab
Gui.Text
Gui.TreeView
Gui.UpDown
IndexError
InputHook
Integer
KeyError
Map
MemberError
MemoryError
Menu 
MenuBar
MethodError
Number
Object 
OSError
Primitive 
PropertyError
RegExMatchInfo
String
TargetError
TimeoutError
TypeError
ValueError
VarRef
ZeroDivisionError
```

</details>

Aside from adding `VarRef`, I've attempted to improve the highlighting of built-in Gui Control subclasses. The case-insensitive pattern expects to see, *on the same line*, **no** dot accessors, followed by `Gui`, followed by a dot accessor and lastly, followed by the name of a Gui Control subclass. Technically, due to [line continuation](https://lexikos.github.io/v2/docs/Scripts.htm#continuation-line), it is permitted for the dot accessor and subclass name to appear on any subsequent line. An example of that is:
```ahk
MsgBox(Type(Gui
.Control))
```
I'm not aware whether VS Code's highlighting engine is equipped to handle such scenarios. Unfortunately, I don't know enough about it to implement that myself, in case it *is*.

One problem with this proposed implementation I've spotted, is the order in which the scopes are being applied to Gui subclasses in some cases. The following screencast illustrates the issue in the highlighting of the `extends` clause.

<details>
<summary>Gui Control Classes</summary>

```ahk
class MyControl extends Gui.Custom
{

}
Gui
Gui.ActiveX
Gui.Button
Gui.CheckBox
Gui.ComboBox
Gui.Control 
Gui.Custom
Gui.DateTime
Gui.DDL
Gui.Edit
Gui.GroupBox
Gui.Hotkey
Gui.Link
Gui.List
Gui.ListBox
Gui.ListView
Gui.MonthCal
Gui.Pic
Gui.Progress
Gui.Radio
Gui.Slider
Gui.StatusBar
Gui.Tab
Gui.Text
Gui.TreeView
Gui.UpDown
RandomCharsGui.UpDown
```

</details>

![GuiControlClasses](https://user-images.githubusercontent.com/25468197/124408606-da02d500-dd46-11eb-96de-a2e6da9813d0.gif)

Tested with [`AutoHotkey_L v2.0-a138-7538f26`](https://github.com/Lexikos/AutoHotkey_L/releases/tag/v2.0-a138).