### PR TITLE
[v2-a138] Update highlighting for directives

### DIFF
--- a/syntaxes/ahk2.json
+++ b/syntaxes/ahk2.json
@@ -71,11 +71,6 @@
 			"prefix": "#MaxThreadsPerHotkey"
 		},
 		{
-			"body": "#MenuMaskKey ",
-			"description": "更改用来掩饰(屏蔽) Win 或 Alt 键松开事件的按键.",
-			"prefix": "#MenuMaskKey"
-		},
-		{
 			"body": "#NoTrayIcon",
 			"description": "禁止显示托盘图标.",
 			"prefix": "#NoTrayIcon"

--- a/syntaxes/ahk2.tmLanguage.json
+++ b/syntaxes/ahk2.tmLanguage.json
@@ -1344,7 +1344,7 @@
           ]
         },
         {
-          "match": "^\\s*((#)(?i:clipboardtimeout|criticalobject(sleeptime|timeout)|hotif|hotiftimeout|hotkeymodifiertimeout|inputlevel|maxthreads|maxthreadsbuffer|maxthreadsperhotkey|menumaskkey|notrayicon|singleinstance|suspendexempt|usehook|warn|warncontinuableexception|winactivateforce))\\b",
+          "match": "^\\s*((#)(?i:clipboardtimeout|criticalobject(sleeptime|timeout)|hotif|hotiftimeout|inputlevel|maxthreads|maxthreadsbuffer|maxthreadsperhotkey|notrayicon|singleinstance|suspendexempt|usehook|warn|warncontinuableexception|winactivateforce))\\b",
           "captures": {
             "1": {
               "name": "keyword.control.directive.ahk2"


### PR DESCRIPTION
|Directive|Reason for removal|
|---|---|
|`#hotkeymodifiertimeout`|Deprecated, use `A_HotkeyModifierTimeout`|
|`#menumaskkey`|Deprecated, use `A_MenuMaskKey`|

Tested with [`AutoHotkey_L v2.0-a138-7538f26`](https://github.com/Lexikos/AutoHotkey_L/releases/tag/v2.0-a138).