### PR TITLE
Trim '`t' -> ' `t'

### DIFF
--- a/syntaxes/ahk2.d.ahk
+++ b/syntaxes/ahk2.d.ahk
@@ -1417,7 +1417,7 @@ Log(Number) => Number
 /**
  * Trim characters from the beginning of the string.
  */
-LTrim(String, OmitChars := '`t') => String
+LTrim(String, OmitChars := ' `t') => String
 
 /**
  * Returns the maximum value of one or more numbers.
@@ -1826,7 +1826,7 @@ Round(Number, N := 0) => Number | String
 /**
  * Trim characters from the end of the string.
  */
-RTrim(String, OmitChars := '`t') => String
+RTrim(String, OmitChars := ' `t') => String
 
 /**
  * Run external programs.
@@ -2261,7 +2261,7 @@ TrayTip(Text := '', Title := '', Options := 0) => void
 /**
  * Trim characters from the beginning and end of the string.
  */
-Trim(String, OmitChars := '`t') => String
+Trim(String, OmitChars := ' `t') => String
 
 /**
  * The exact type of the return value.


### PR DESCRIPTION
doesn't happen here: https://github.com/thqby/vscode-autohotkey2-lsp/blob/9f93990baae187bfb444aee4a70e75ecedd18db5/syntaxes/zh-cn/ahk2.d.ahk#L1829, meaning it's not automatically generated