### PR TITLE
Fixed missing meta function

### DIFF
--- a/syntaxes/ahk2.json
+++ b/syntaxes/ahk2.json
@@ -353,6 +353,10 @@
 			"prefix": "__New"
 		},
 		{
+			"body": "__Init($0)",
+			"prefix": "__Init"
+		},
+		{
 			"body": "__Set(${1:Key}, ${2:Params}, ${3:Value})",
 			"prefix": "__Set"
 		}


### PR DESCRIPTION
The snippet library has entries for `__new` and other meta functions but it doesnt contain one for `__init`