### PR TITLE
Added a code class (token) for parent objects

### DIFF
--- a/syntaxes/ahk2.tmLanguage.json
+++ b/syntaxes/ahk2.tmLanguage.json
@@ -1729,11 +1729,6 @@
             }
           },
           "name": "meta.objectliteral.ahk2"
-        },
-        {
-          "comment": "this will catch any parent object, without catching any child objects. while this is a simple solution, it's effective for the time being. if you'd be interested, you could add a better implementation later, I'm sure I'm not the only one who wants to color objects",
-          "match": "(?<!\\.)(?!\\d)(\\w+)(?=\\.)",
-          "name": "variable.other.object.ahk2"
         }
       ]
     },
@@ -2232,9 +2227,12 @@
       ]
     },
     "variables": {
-      "match": "(?<!\\.)\\b\\w+\\b(?!\\()",
+      "match": "(?<!\\.)\\b((\\w+(?=\\.))|(\\w+\\b(?!\\()))",
       "captures": {
-        "0": {
+        "2": {
+          "name": "variable.other.object.ahk2"
+        },
+        "3": {
           "patterns": [
             {
               "include": "#object_property"

--- a/syntaxes/ahk2.tmLanguage.json
+++ b/syntaxes/ahk2.tmLanguage.json
@@ -1732,7 +1732,7 @@
         },
         {
           "comment": "this will catch any parent object, without catching any child objects. while this is a simple solution, it's effective for the time being. if you'd be interested, you could add a better implementation later, I'm sure I'm not the only one who wants to color objects",
-          "match": "(?<!\\.)(\\w+)(?=\\.)",
+          "match": "(?<!\\.)(?!\\d)(\\w+)(?=\\.)",
           "name": "variable.other.object.ahk2"
         }
       ]

--- a/syntaxes/ahk2.tmLanguage.json
+++ b/syntaxes/ahk2.tmLanguage.json
@@ -1729,6 +1729,11 @@
             }
           },
           "name": "meta.objectliteral.ahk2"
+        },
+        {
+          "comment": "this will catch any parent object, without catching any child objects. while this is a simple solution, it's effective for the time being. if you'd be interested, you could add a better implementation later, I'm sure I'm not the only one who wants to color objects",
+          "match": "(?<!\\.)(\\w+)(?=\\.)",
+          "name": "variable.other.object.ahk2"
         }
       ]
     },


### PR DESCRIPTION
Usually, variables and objects are seen as the same `variable.other.ahk2`, so to make objects more visible, you can highlight properties or methods

I find it strange that you can't highlight the *object* instead

![image](https://user-images.githubusercontent.com/101342105/187842582-ce8a8f69-95b2-408c-b744-62b513ebffce.png)

So I implemented a simple solution to make that a possibility

This way me, and potentially some others won't have to go in and add the same code every time your extension updates