### PR TITLE
fix: MenuSelect Wintext parameter is optional

### DIFF
--- a/syntaxes/ahk2.d.ahk
+++ b/syntaxes/ahk2.d.ahk
@@ -1454,7 +1454,7 @@ MenuFromHandle(Handle) => Menu
  * 
  * Specify 0& to use the system menu of the window.
  */
-MenuSelect(WinTitle, WinText, Menu [, SubMenu1, SubMenu2, SubMenu3, SubMenu4, SubMenu5, SubMenu6, ExcludeTitle, ExcludeText]) => void
+MenuSelect(WinTitle, [WinText], Menu [, SubMenu1, SubMenu2, SubMenu3, SubMenu4, SubMenu5, SubMenu6, ExcludeTitle, ExcludeText]) => void
 
 /**
  * Returns the minimum value of one or more numbers.


### PR DESCRIPTION

https://lexikos.github.io/v2/docs/commands/MenuSelect.htm

WinText
Type: String

**If present**, this parameter must be a substring from a single text element of the target window (as revealed by the included Window Spy utility). Hidden text elements are detected if DetectHiddenText is ON.