### PR TITLE
Improved interpreter path resolving

### DIFF
--- a/server/src/ahkProvider.ts
+++ b/server/src/ahkProvider.ts
@@ -1,14 +1,13 @@
 import { createClientSocketTransport, createMessageConnection, createServerSocketTransport, MessageConnection } from 'vscode-languageserver/node';
 import { spawn } from 'child_process';
-import { existsSync } from 'fs';
 import { type } from 'os';
-import { ahkpath_cur, rootdir, extsettings } from './common';
+import { ahkpath_cur, rootdir, extsettings, resolvePathSync } from './common';
 let ahk_server: MessageConnection | undefined | null;
 
 async function get_ahkProvider_port(): Promise<number> {
 	return new Promise(async (resolve, reject) => {
-		let executePath = ahkpath_cur || extsettings.InterpreterPath;
-		if (!existsSync(executePath))
+		let executePath = resolvePathSync(ahkpath_cur) || resolvePathSync(extsettings.InterpreterPath);
+		if (!executePath)
 			return resolve(0);
 		let server, port = 1200;
 		while (true) {

--- a/server/src/scriptrunner.ts
+++ b/server/src/scriptrunner.ts
@@ -1,10 +1,9 @@
 import { spawnSync } from 'child_process';
-import { ahkpath_cur, extsettings } from './common';
-import { existsSync } from 'fs';
+import { ahkpath_cur, extsettings, resolvePathSync } from './common';
 
 export function runscript(script: string, out?: Function): boolean {
-	let executePath = ahkpath_cur || extsettings.InterpreterPath;
-	if (existsSync(executePath)) {
+	let executePath = resolvePathSync(ahkpath_cur) || resolvePathSync(extsettings.InterpreterPath);
+	if (executePath) {
 		const process = spawnSync(`\"${executePath}\" /CP65001 /ErrorStdOut=utf-8 *`, [], { cwd: executePath.replace(/[\\/].+?$/, ''), shell: true, input: script });
 		if (process) {
 			if (out)


### PR DESCRIPTION
This is a possible solution for issue #394. It mostly tries to replace `existsSync` to support commands and symlinks.

These are the main functions it uses:
```
const commandExistsSync = require('command-exists').sync
const existsSyncEx = (path: string): boolean => {
    try { lstatSync(path); } catch (err) {
      if ((err as any)?.code === 'ENOENT') return false;
    }
    return true;
  };
const resolvePathSync = (path: string): string => {
	if (!path)
		return ""
	if (commandExistsSync(path)) // resolves a command
		path = execSync('where ' + path).toString().trim();
	try { // now try to resolve a symlink and check whether the file exists
		if (lstatSync(path).isSymbolicLink()) // lstatSync throws if file is not found
			path = readlinkSync(path);
	} catch {
		return ""
	}
	return path
}
```

1) `commandExistsSync` requires the package `command-exists` and is used to check for valid commands. This is so AutoHotkey2.InterpreterPath values such as `AutoHotkey` or `AutoHotkey.exe` could be confirmed as valid "paths" which will be resolved later.
2) `existsSyncEx` uses `lstatSync` to check whether a file or symlink exists, because `existsSync` reports "false" for the problematic symlinks I mentioned in my original post. `lstatSync` is used instead of `statSync` because the latter throws a "permission denied" error when used on a restricted file (probably because some unneeded permissions are asked when resolving the symlink?)
3) `resolvePathSync` resolves both commands and symlinks to their real paths. This is needed because you are using `PEFile.getResource` which if used on the symlink throws an error, whereas interacting with the actual executable causes no such problems. For example, if AHK Microsoft Store edition is installed, `resolvePathSync` turns `AutoHotkey` (command) and `C:\Users\user\AppData\Local\Microsoft\WindowsApps\AutoHotkey.exe` (symlink) into `C:\Program Files\WindowsApps\HaukeGtze.AutoHotkeypoweredbyweatherlights.com_1.1137.101.0_x64__6bk20wvc8rfx2\AutoHotkey.exe` and if a called on a non-existant file then returns an empty string.

I tried implementing these in the extension in the files using existsSync (extension.ts, ahkProvider.ts, scriptrunner.ts, server.ts) and it seems to fix all the problems. Feel free to reject it and use it as a base for your own implementation if it causes any problems I haven't noticed yet...