### PR TITLE
Resolve package-lock issues and fix ESLint

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
 				"@eslint/js": "^9.4.0",
 				"@types/vscode": "^1.82.0",
 				"@vscode/vsce": "^2.27.0",
-				"eslint": "^9.4.0",
+				"eslint": "^8.57.0",
 				"globals": "^15.4.0",
 				"path-browserify": "^1.0.1",
 				"ts-loader": "^9.4.0",
@@ -280,19 +280,6 @@
 				"eslint": "^6.0.0 || ^7.0.0 || >=8.0.0"
 			}
 		},
-		"node_modules/@eslint-community/eslint-utils/node_modules/eslint-visitor-keys": {
-			"version": "3.4.3",
-			"resolved": "https://registry.npmmirror.com/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
-			"integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"engines": {
-				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-			},
-			"funding": {
-				"url": "https://opencollective.com/eslint"
-			}
-		},
 		"node_modules/@eslint-community/regexpp": {
 			"version": "4.10.1",
 			"resolved": "https://registry.npmmirror.com/@eslint-community/regexpp/-/regexpp-4.10.1.tgz",
@@ -303,32 +290,17 @@
 				"node": "^12.0.0 || ^14.0.0 || >=16.0.0"
 			}
 		},
-		"node_modules/@eslint/config-array": {
-			"version": "0.15.1",
-			"resolved": "https://registry.npmmirror.com/@eslint/config-array/-/config-array-0.15.1.tgz",
-			"integrity": "sha512-K4gzNq+yymn/EVsXYmf+SBcBro8MTf+aXJZUphM96CdzUEr+ClGDvAbpmaEK+cGVigVXIgs9gNmvHAlrzzY5JQ==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@eslint/object-schema": "^2.1.3",
-				"debug": "^4.3.1",
-				"minimatch": "^3.0.5"
-			},
-			"engines": {
-				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-			}
-		},
 		"node_modules/@eslint/eslintrc": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmmirror.com/@eslint/eslintrc/-/eslintrc-3.1.0.tgz",
-			"integrity": "sha512-4Bfj15dVJdoy3RfZmmo86RK1Fwzn6SstsvK9JS+BaVKqC6QQQQyXekNaC+g+LKNgkQ+2VhGAzm6hO40AhMR3zQ==",
+			"version": "2.1.4",
+			"resolved": "https://registry.npmmirror.com/@eslint/eslintrc/-/eslintrc-2.1.4.tgz",
+			"integrity": "sha512-269Z39MS6wVJtsoUl10L60WdkhJVdPG24Q4eZTH3nnF6lpvSShEK3wQjDX9JRWAUPvPh7COouPpU9IrqaZFvtQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"ajv": "^6.12.4",
 				"debug": "^4.3.2",
-				"espree": "^10.0.1",
-				"globals": "^14.0.0",
+				"espree": "^9.6.0",
+				"globals": "^13.19.0",
 				"ignore": "^5.2.0",
 				"import-fresh": "^3.2.1",
 				"js-yaml": "^4.1.0",
@@ -336,20 +308,23 @@
 				"strip-json-comments": "^3.1.1"
 			},
 			"engines": {
-				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
 			},
 			"funding": {
 				"url": "https://opencollective.com/eslint"
 			}
 		},
 		"node_modules/@eslint/eslintrc/node_modules/globals": {
-			"version": "14.0.0",
-			"resolved": "https://registry.npmmirror.com/globals/-/globals-14.0.0.tgz",
-			"integrity": "sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==",
+			"version": "13.24.0",
+			"resolved": "https://registry.npmmirror.com/globals/-/globals-13.24.0.tgz",
+			"integrity": "sha512-AhO5QUcj8llrbG09iWhPU2B204J1xnPeL8kQmVorSsy+Sjj1sk8gIyh6cUocGmH4L0UuhAJy+hJMRA4mgA4mFQ==",
 			"dev": true,
 			"license": "MIT",
+			"dependencies": {
+				"type-fest": "^0.20.2"
+			},
 			"engines": {
-				"node": ">=18"
+				"node": ">=8"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
@@ -378,14 +353,20 @@
 				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
 			}
 		},
-		"node_modules/@eslint/object-schema": {
-			"version": "2.1.3",
-			"resolved": "https://registry.npmmirror.com/@eslint/object-schema/-/object-schema-2.1.3.tgz",
-			"integrity": "sha512-HAbhAYKfsAC2EkTqve00ibWIZlaU74Z1EHwAjYr4PXF0YU2VEA1zSIKSSpKszRLRWwHzzRZXvK632u+uXzvsvw==",
+		"node_modules/@humanwhocodes/config-array": {
+			"version": "0.11.14",
+			"resolved": "https://registry.npmmirror.com/@humanwhocodes/config-array/-/config-array-0.11.14.tgz",
+			"integrity": "sha512-3T8LkOmg45BV5FICb15QQMsyUSWrQ8AygVfC7ZG32zOalnqrilm018ZVCw0eapXux8FtA33q8PSRSstjee3jSg==",
+			"deprecated": "Use @eslint/config-array instead",
 			"dev": true,
 			"license": "Apache-2.0",
+			"dependencies": {
+				"@humanwhocodes/object-schema": "^2.0.2",
+				"debug": "^4.3.1",
+				"minimatch": "^3.0.5"
+			},
 			"engines": {
-				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+				"node": ">=10.10.0"
 			}
 		},
 		"node_modules/@humanwhocodes/module-importer": {
@@ -402,19 +383,13 @@
 				"url": "https://github.com/sponsors/nzakas"
 			}
 		},
-		"node_modules/@humanwhocodes/retry": {
-			"version": "0.3.0",
-			"resolved": "https://registry.npmmirror.com/@humanwhocodes/retry/-/retry-0.3.0.tgz",
-			"integrity": "sha512-d2CGZR2o7fS6sWB7DG/3a95bGKQyHMACZ5aW8qGkkqQpUoZV6C0X7Pc7l4ZNMZkfNBf4VWNe9E1jRsf0G146Ew==",
+		"node_modules/@humanwhocodes/object-schema": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmmirror.com/@humanwhocodes/object-schema/-/object-schema-2.0.3.tgz",
+			"integrity": "sha512-93zYdMES/c1D69yZiKDBj0V24vqNzB/koF26KPaagAfd3P/4gUlh3Dys5ogAK+Exi9QyzlD8x/08Zt7wIKcDcA==",
+			"deprecated": "Use @eslint/object-schema instead",
 			"dev": true,
-			"license": "Apache-2.0",
-			"engines": {
-				"node": ">=18.18"
-			},
-			"funding": {
-				"type": "github",
-				"url": "https://github.com/sponsors/nzakas"
-			}
+			"license": "BSD-3-Clause"
 		},
 		"node_modules/@jridgewell/gen-mapping": {
 			"version": "0.3.5",
@@ -676,18 +651,12 @@
 				"url": "https://opencollective.com/typescript-eslint"
 			}
 		},
-		"node_modules/@typescript-eslint/visitor-keys/node_modules/eslint-visitor-keys": {
-			"version": "3.4.3",
-			"resolved": "https://registry.npmmirror.com/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
-			"integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
+		"node_modules/@ungap/structured-clone": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmmirror.com/@ungap/structured-clone/-/structured-clone-1.2.0.tgz",
+			"integrity": "sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ==",
 			"dev": true,
-			"license": "Apache-2.0",
-			"engines": {
-				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-			},
-			"funding": {
-				"url": "https://opencollective.com/eslint"
-			}
+			"license": "ISC"
 		},
 		"node_modules/@vscode/vsce": {
 			"version": "2.27.0",
@@ -1739,6 +1708,19 @@
 				"node": ">=8"
 			}
 		},
+		"node_modules/doctrine": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmmirror.com/doctrine/-/doctrine-3.0.0.tgz",
+			"integrity": "sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"esutils": "^2.0.2"
+			},
+			"engines": {
+				"node": ">=6.0.0"
+			}
+		},
 		"node_modules/dom-serializer": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmmirror.com/dom-serializer/-/dom-serializer-2.0.0.tgz",
@@ -1917,38 +1899,42 @@
 			}
 		},
 		"node_modules/eslint": {
-			"version": "9.4.0",
-			"resolved": "https://registry.npmmirror.com/eslint/-/eslint-9.4.0.tgz",
-			"integrity": "sha512-sjc7Y8cUD1IlwYcTS9qPSvGjAC8Ne9LctpxKKu3x/1IC9bnOg98Zy6GxEJUfr1NojMgVPlyANXYns8oE2c1TAA==",
+			"version": "8.57.0",
+			"resolved": "https://registry.npmmirror.com/eslint/-/eslint-8.57.0.tgz",
+			"integrity": "sha512-dZ6+mexnaTIbSBZWgou51U6OmzIhYM2VcNdtiTtI7qPNZm35Akpr0f6vtw3w1Kmn5PYo+tZVfh13WrhpS6oLqQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@eslint-community/eslint-utils": "^4.2.0",
 				"@eslint-community/regexpp": "^4.6.1",
-				"@eslint/config-array": "^0.15.1",
-				"@eslint/eslintrc": "^3.1.0",
-				"@eslint/js": "9.4.0",
+				"@eslint/eslintrc": "^2.1.4",
+				"@eslint/js": "8.57.0",
+				"@humanwhocodes/config-array": "^0.11.14",
 				"@humanwhocodes/module-importer": "^1.0.1",
-				"@humanwhocodes/retry": "^0.3.0",
 				"@nodelib/fs.walk": "^1.2.8",
+				"@ungap/structured-clone": "^1.2.0",
 				"ajv": "^6.12.4",
 				"chalk": "^4.0.0",
 				"cross-spawn": "^7.0.2",
 				"debug": "^4.3.2",
+				"doctrine": "^3.0.0",
 				"escape-string-regexp": "^4.0.0",
-				"eslint-scope": "^8.0.1",
-				"eslint-visitor-keys": "^4.0.0",
-				"espree": "^10.0.1",
+				"eslint-scope": "^7.2.2",
+				"eslint-visitor-keys": "^3.4.3",
+				"espree": "^9.6.1",
 				"esquery": "^1.4.2",
 				"esutils": "^2.0.2",
 				"fast-deep-equal": "^3.1.3",
-				"file-entry-cache": "^8.0.0",
+				"file-entry-cache": "^6.0.1",
 				"find-up": "^5.0.0",
 				"glob-parent": "^6.0.2",
+				"globals": "^13.19.0",
+				"graphemer": "^1.4.0",
 				"ignore": "^5.2.0",
 				"imurmurhash": "^0.1.4",
 				"is-glob": "^4.0.0",
 				"is-path-inside": "^3.0.3",
+				"js-yaml": "^4.1.0",
 				"json-stable-stringify-without-jsonify": "^1.0.1",
 				"levn": "^0.4.1",
 				"lodash.merge": "^4.6.2",
@@ -1962,7 +1948,7 @@
 				"eslint": "bin/eslint.js"
 			},
 			"engines": {
-				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
 			},
 			"funding": {
 				"url": "https://opencollective.com/eslint"
@@ -1983,16 +1969,26 @@
 			}
 		},
 		"node_modules/eslint-visitor-keys": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmmirror.com/eslint-visitor-keys/-/eslint-visitor-keys-4.0.0.tgz",
-			"integrity": "sha512-OtIRv/2GyiF6o/d8K7MYKKbXrOUBIK6SfkIRM4Z0dY3w+LiQ0vy3F57m0Z71bjbyeiWFiHJ8brqnmE6H6/jEuw==",
+			"version": "3.4.3",
+			"resolved": "https://registry.npmmirror.com/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+			"integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"engines": {
-				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
 			},
 			"funding": {
 				"url": "https://opencollective.com/eslint"
+			}
+		},
+		"node_modules/eslint/node_modules/@eslint/js": {
+			"version": "8.57.0",
+			"resolved": "https://registry.npmmirror.com/@eslint/js/-/js-8.57.0.tgz",
+			"integrity": "sha512-Ys+3g2TaW7gADOJzPt83SJtCDhMjndcDMFVQ/Tj9iA1BfJzFKD9mAUXT3OenpuPHbI6P/myECxRJrofUsDx/5g==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
 			}
 		},
 		"node_modules/eslint/node_modules/ansi-styles": {
@@ -2062,9 +2058,9 @@
 			}
 		},
 		"node_modules/eslint/node_modules/eslint-scope": {
-			"version": "8.0.1",
-			"resolved": "https://registry.npmmirror.com/eslint-scope/-/eslint-scope-8.0.1.tgz",
-			"integrity": "sha512-pL8XjgP4ZOmmwfFE8mEhSxA7ZY4C+LWyqjQ3o4yWkkmD0qcMT9kkW3zWHOczhWcjTSgqycYAgwSlXvZltv65og==",
+			"version": "7.2.2",
+			"resolved": "https://registry.npmmirror.com/eslint-scope/-/eslint-scope-7.2.2.tgz",
+			"integrity": "sha512-dOt21O7lTMhDM+X9mB4GX+DZrZtCUJPL/wlcTqxyrx5IvO0IYtILdtrQGQp+8n5S0gwSVmOf9NQrjMOgfQZlIg==",
 			"dev": true,
 			"license": "BSD-2-Clause",
 			"dependencies": {
@@ -2072,7 +2068,7 @@
 				"estraverse": "^5.2.0"
 			},
 			"engines": {
-				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
 			},
 			"funding": {
 				"url": "https://opencollective.com/eslint"
@@ -2100,6 +2096,22 @@
 			},
 			"engines": {
 				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/eslint/node_modules/globals": {
+			"version": "13.24.0",
+			"resolved": "https://registry.npmmirror.com/globals/-/globals-13.24.0.tgz",
+			"integrity": "sha512-AhO5QUcj8llrbG09iWhPU2B204J1xnPeL8kQmVorSsy+Sjj1sk8gIyh6cUocGmH4L0UuhAJy+hJMRA4mgA4mFQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"type-fest": "^0.20.2"
+			},
+			"engines": {
+				"node": ">=8"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
@@ -2177,18 +2189,18 @@
 			}
 		},
 		"node_modules/espree": {
-			"version": "10.0.1",
-			"resolved": "https://registry.npmmirror.com/espree/-/espree-10.0.1.tgz",
-			"integrity": "sha512-MWkrWZbJsL2UwnjxTX3gG8FneachS/Mwg7tdGXce011sJd5b0JG54vat5KHnfSBODZ3Wvzd2WnjxyzsRoVv+ww==",
+			"version": "9.6.1",
+			"resolved": "https://registry.npmmirror.com/espree/-/espree-9.6.1.tgz",
+			"integrity": "sha512-oruZaFkjorTpF32kDSI5/75ViwGeZginGGy2NoOSg3Q9bnwlnmDm4HLnkl0RE3n+njDXR037aY1+x58Z/zFdwQ==",
 			"dev": true,
 			"license": "BSD-2-Clause",
 			"dependencies": {
-				"acorn": "^8.11.3",
+				"acorn": "^8.9.0",
 				"acorn-jsx": "^5.3.2",
-				"eslint-visitor-keys": "^4.0.0"
+				"eslint-visitor-keys": "^3.4.1"
 			},
 			"engines": {
-				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
 			},
 			"funding": {
 				"url": "https://opencollective.com/eslint"
@@ -2363,16 +2375,16 @@
 			}
 		},
 		"node_modules/file-entry-cache": {
-			"version": "8.0.0",
-			"resolved": "https://registry.npmmirror.com/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
-			"integrity": "sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==",
+			"version": "6.0.1",
+			"resolved": "https://registry.npmmirror.com/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
+			"integrity": "sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"flat-cache": "^4.0.0"
+				"flat-cache": "^3.0.4"
 			},
 			"engines": {
-				"node": ">=16.0.0"
+				"node": "^10.12.0 || >=12.0.0"
 			}
 		},
 		"node_modules/fill-range": {
@@ -2413,17 +2425,18 @@
 			}
 		},
 		"node_modules/flat-cache": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmmirror.com/flat-cache/-/flat-cache-4.0.1.tgz",
-			"integrity": "sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==",
+			"version": "3.2.0",
+			"resolved": "https://registry.npmmirror.com/flat-cache/-/flat-cache-3.2.0.tgz",
+			"integrity": "sha512-CYcENa+FtcUKLmhhqyctpclsq7QF38pKjZHsGNiSQF5r4FtoKDWabFDl3hzaEQMvT1LHEysw5twgLvpYYb4vbw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"flatted": "^3.2.9",
-				"keyv": "^4.5.4"
+				"keyv": "^4.5.3",
+				"rimraf": "^3.0.2"
 			},
 			"engines": {
-				"node": ">=16"
+				"node": "^10.12.0 || >=12.0.0"
 			}
 		},
 		"node_modules/flatted": {
@@ -3977,6 +3990,23 @@
 				"node": ">=0.10.0"
 			}
 		},
+		"node_modules/rimraf": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmmirror.com/rimraf/-/rimraf-3.0.2.tgz",
+			"integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+			"deprecated": "Rimraf versions prior to v4 are no longer supported",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"glob": "^7.1.3"
+			},
+			"bin": {
+				"rimraf": "bin.js"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
 		"node_modules/run-parallel": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmmirror.com/run-parallel/-/run-parallel-1.2.0.tgz",
@@ -4590,6 +4620,19 @@
 			},
 			"engines": {
 				"node": ">= 0.8.0"
+			}
+		},
+		"node_modules/type-fest": {
+			"version": "0.20.2",
+			"resolved": "https://registry.npmmirror.com/type-fest/-/type-fest-0.20.2.tgz",
+			"integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
+			"dev": true,
+			"license": "(MIT OR CC0-1.0)",
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/typed-rest-client": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
 				"@eslint/js": "^9.4.0",
 				"@types/vscode": "^1.82.0",
 				"@vscode/vsce": "^2.27.0",
-				"eslint": "^8.57.0",
+				"eslint": "^9.4.0",
 				"globals": "^15.4.0",
 				"path-browserify": "^1.0.1",
 				"ts-loader": "^9.4.0",
@@ -290,17 +290,32 @@
 				"node": "^12.0.0 || ^14.0.0 || >=16.0.0"
 			}
 		},
+		"node_modules/@eslint/config-array": {
+			"version": "0.16.0",
+			"resolved": "https://registry.npmmirror.com/@eslint/config-array/-/config-array-0.16.0.tgz",
+			"integrity": "sha512-/jmuSd74i4Czf1XXn7wGRWZCuyaUZ330NH1Bek0Pplatt4Sy1S5haN21SCLLdbeKslQ+S0wEJ+++v5YibSi+Lg==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@eslint/object-schema": "^2.1.4",
+				"debug": "^4.3.1",
+				"minimatch": "^3.0.5"
+			},
+			"engines": {
+				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+			}
+		},
 		"node_modules/@eslint/eslintrc": {
-			"version": "2.1.4",
-			"resolved": "https://registry.npmmirror.com/@eslint/eslintrc/-/eslintrc-2.1.4.tgz",
-			"integrity": "sha512-269Z39MS6wVJtsoUl10L60WdkhJVdPG24Q4eZTH3nnF6lpvSShEK3wQjDX9JRWAUPvPh7COouPpU9IrqaZFvtQ==",
+			"version": "3.1.0",
+			"resolved": "https://registry.npmmirror.com/@eslint/eslintrc/-/eslintrc-3.1.0.tgz",
+			"integrity": "sha512-4Bfj15dVJdoy3RfZmmo86RK1Fwzn6SstsvK9JS+BaVKqC6QQQQyXekNaC+g+LKNgkQ+2VhGAzm6hO40AhMR3zQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"ajv": "^6.12.4",
 				"debug": "^4.3.2",
-				"espree": "^9.6.0",
-				"globals": "^13.19.0",
+				"espree": "^10.0.1",
+				"globals": "^14.0.0",
 				"ignore": "^5.2.0",
 				"import-fresh": "^3.2.1",
 				"js-yaml": "^4.1.0",
@@ -308,23 +323,20 @@
 				"strip-json-comments": "^3.1.1"
 			},
 			"engines": {
-				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
 			},
 			"funding": {
 				"url": "https://opencollective.com/eslint"
 			}
 		},
 		"node_modules/@eslint/eslintrc/node_modules/globals": {
-			"version": "13.24.0",
-			"resolved": "https://registry.npmmirror.com/globals/-/globals-13.24.0.tgz",
-			"integrity": "sha512-AhO5QUcj8llrbG09iWhPU2B204J1xnPeL8kQmVorSsy+Sjj1sk8gIyh6cUocGmH4L0UuhAJy+hJMRA4mgA4mFQ==",
+			"version": "14.0.0",
+			"resolved": "https://registry.npmmirror.com/globals/-/globals-14.0.0.tgz",
+			"integrity": "sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==",
 			"dev": true,
 			"license": "MIT",
-			"dependencies": {
-				"type-fest": "^0.20.2"
-			},
 			"engines": {
-				"node": ">=8"
+				"node": ">=18"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
@@ -344,29 +356,23 @@
 			}
 		},
 		"node_modules/@eslint/js": {
-			"version": "9.4.0",
-			"resolved": "https://registry.npmmirror.com/@eslint/js/-/js-9.4.0.tgz",
-			"integrity": "sha512-fdI7VJjP3Rvc70lC4xkFXHB0fiPeojiL1PxVG6t1ZvXQrarj893PweuBTujxDUFk0Fxj4R7PIIAZ/aiiyZPZcg==",
+			"version": "9.5.0",
+			"resolved": "https://registry.npmmirror.com/@eslint/js/-/js-9.5.0.tgz",
+			"integrity": "sha512-A7+AOT2ICkodvtsWnxZP4Xxk3NbZ3VMHd8oihydLRGrJgqqdEz1qSeEgXYyT/Cu8h1TWWsQRejIx48mtjZ5y1w==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
 			}
 		},
-		"node_modules/@humanwhocodes/config-array": {
-			"version": "0.11.14",
-			"resolved": "https://registry.npmmirror.com/@humanwhocodes/config-array/-/config-array-0.11.14.tgz",
-			"integrity": "sha512-3T8LkOmg45BV5FICb15QQMsyUSWrQ8AygVfC7ZG32zOalnqrilm018ZVCw0eapXux8FtA33q8PSRSstjee3jSg==",
-			"deprecated": "Use @eslint/config-array instead",
+		"node_modules/@eslint/object-schema": {
+			"version": "2.1.4",
+			"resolved": "https://registry.npmmirror.com/@eslint/object-schema/-/object-schema-2.1.4.tgz",
+			"integrity": "sha512-BsWiH1yFGjXXS2yvrf5LyuoSIIbPrGUWob917o+BTKuZ7qJdxX8aJLRxs1fS9n6r7vESrq1OUqb68dANcFXuQQ==",
 			"dev": true,
 			"license": "Apache-2.0",
-			"dependencies": {
-				"@humanwhocodes/object-schema": "^2.0.2",
-				"debug": "^4.3.1",
-				"minimatch": "^3.0.5"
-			},
 			"engines": {
-				"node": ">=10.10.0"
+				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
 			}
 		},
 		"node_modules/@humanwhocodes/module-importer": {
@@ -383,13 +389,19 @@
 				"url": "https://github.com/sponsors/nzakas"
 			}
 		},
-		"node_modules/@humanwhocodes/object-schema": {
-			"version": "2.0.3",
-			"resolved": "https://registry.npmmirror.com/@humanwhocodes/object-schema/-/object-schema-2.0.3.tgz",
-			"integrity": "sha512-93zYdMES/c1D69yZiKDBj0V24vqNzB/koF26KPaagAfd3P/4gUlh3Dys5ogAK+Exi9QyzlD8x/08Zt7wIKcDcA==",
-			"deprecated": "Use @eslint/object-schema instead",
+		"node_modules/@humanwhocodes/retry": {
+			"version": "0.3.0",
+			"resolved": "https://registry.npmmirror.com/@humanwhocodes/retry/-/retry-0.3.0.tgz",
+			"integrity": "sha512-d2CGZR2o7fS6sWB7DG/3a95bGKQyHMACZ5aW8qGkkqQpUoZV6C0X7Pc7l4ZNMZkfNBf4VWNe9E1jRsf0G146Ew==",
 			"dev": true,
-			"license": "BSD-3-Clause"
+			"license": "Apache-2.0",
+			"engines": {
+				"node": ">=18.18"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/nzakas"
+			}
 		},
 		"node_modules/@jridgewell/gen-mapping": {
 			"version": "0.3.5",
@@ -650,13 +662,6 @@
 				"type": "opencollective",
 				"url": "https://opencollective.com/typescript-eslint"
 			}
-		},
-		"node_modules/@ungap/structured-clone": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmmirror.com/@ungap/structured-clone/-/structured-clone-1.2.0.tgz",
-			"integrity": "sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ==",
-			"dev": true,
-			"license": "ISC"
 		},
 		"node_modules/@vscode/vsce": {
 			"version": "2.27.0",
@@ -1060,9 +1065,9 @@
 			"license": "Apache-2.0"
 		},
 		"node_modules/acorn": {
-			"version": "8.11.3",
-			"resolved": "https://registry.npmmirror.com/acorn/-/acorn-8.11.3.tgz",
-			"integrity": "sha512-Y9rRfJG5jcKOE0CLisYbojUjIrIEE7AGMzA/Sm4BslANhbS+cDMpgBdcPT91oJ7OuJ9hYJBx59RjbhxVnrF8Xg==",
+			"version": "8.12.0",
+			"resolved": "https://registry.npmmirror.com/acorn/-/acorn-8.12.0.tgz",
+			"integrity": "sha512-RTvkC4w+KNXrM39/lWCUaG0IbRkWdCv7W/IOW9oU6SawyxulvkQy5HQPVTKxEjczcUvapcrw3cFx/60VN/NRNw==",
 			"dev": true,
 			"license": "MIT",
 			"bin": {
@@ -1708,19 +1713,6 @@
 				"node": ">=8"
 			}
 		},
-		"node_modules/doctrine": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmmirror.com/doctrine/-/doctrine-3.0.0.tgz",
-			"integrity": "sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"esutils": "^2.0.2"
-			},
-			"engines": {
-				"node": ">=6.0.0"
-			}
-		},
 		"node_modules/dom-serializer": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmmirror.com/dom-serializer/-/dom-serializer-2.0.0.tgz",
@@ -1899,42 +1891,38 @@
 			}
 		},
 		"node_modules/eslint": {
-			"version": "8.57.0",
-			"resolved": "https://registry.npmmirror.com/eslint/-/eslint-8.57.0.tgz",
-			"integrity": "sha512-dZ6+mexnaTIbSBZWgou51U6OmzIhYM2VcNdtiTtI7qPNZm35Akpr0f6vtw3w1Kmn5PYo+tZVfh13WrhpS6oLqQ==",
+			"version": "9.5.0",
+			"resolved": "https://registry.npmmirror.com/eslint/-/eslint-9.5.0.tgz",
+			"integrity": "sha512-+NAOZFrW/jFTS3dASCGBxX1pkFD0/fsO+hfAkJ4TyYKwgsXZbqzrw+seCYFCcPCYXvnD67tAnglU7GQTz6kcVw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@eslint-community/eslint-utils": "^4.2.0",
 				"@eslint-community/regexpp": "^4.6.1",
-				"@eslint/eslintrc": "^2.1.4",
-				"@eslint/js": "8.57.0",
-				"@humanwhocodes/config-array": "^0.11.14",
+				"@eslint/config-array": "^0.16.0",
+				"@eslint/eslintrc": "^3.1.0",
+				"@eslint/js": "9.5.0",
 				"@humanwhocodes/module-importer": "^1.0.1",
+				"@humanwhocodes/retry": "^0.3.0",
 				"@nodelib/fs.walk": "^1.2.8",
-				"@ungap/structured-clone": "^1.2.0",
 				"ajv": "^6.12.4",
 				"chalk": "^4.0.0",
 				"cross-spawn": "^7.0.2",
 				"debug": "^4.3.2",
-				"doctrine": "^3.0.0",
 				"escape-string-regexp": "^4.0.0",
-				"eslint-scope": "^7.2.2",
-				"eslint-visitor-keys": "^3.4.3",
-				"espree": "^9.6.1",
-				"esquery": "^1.4.2",
+				"eslint-scope": "^8.0.1",
+				"eslint-visitor-keys": "^4.0.0",
+				"espree": "^10.0.1",
+				"esquery": "^1.5.0",
 				"esutils": "^2.0.2",
 				"fast-deep-equal": "^3.1.3",
-				"file-entry-cache": "^6.0.1",
+				"file-entry-cache": "^8.0.0",
 				"find-up": "^5.0.0",
 				"glob-parent": "^6.0.2",
-				"globals": "^13.19.0",
-				"graphemer": "^1.4.0",
 				"ignore": "^5.2.0",
 				"imurmurhash": "^0.1.4",
 				"is-glob": "^4.0.0",
 				"is-path-inside": "^3.0.3",
-				"js-yaml": "^4.1.0",
 				"json-stable-stringify-without-jsonify": "^1.0.1",
 				"levn": "^0.4.1",
 				"lodash.merge": "^4.6.2",
@@ -1948,10 +1936,10 @@
 				"eslint": "bin/eslint.js"
 			},
 			"engines": {
-				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
 			},
 			"funding": {
-				"url": "https://opencollective.com/eslint"
+				"url": "https://eslint.org/donate"
 			}
 		},
 		"node_modules/eslint-scope": {
@@ -1979,16 +1967,6 @@
 			},
 			"funding": {
 				"url": "https://opencollective.com/eslint"
-			}
-		},
-		"node_modules/eslint/node_modules/@eslint/js": {
-			"version": "8.57.0",
-			"resolved": "https://registry.npmmirror.com/@eslint/js/-/js-8.57.0.tgz",
-			"integrity": "sha512-Ys+3g2TaW7gADOJzPt83SJtCDhMjndcDMFVQ/Tj9iA1BfJzFKD9mAUXT3OenpuPHbI6P/myECxRJrofUsDx/5g==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
 			}
 		},
 		"node_modules/eslint/node_modules/ansi-styles": {
@@ -2058,9 +2036,9 @@
 			}
 		},
 		"node_modules/eslint/node_modules/eslint-scope": {
-			"version": "7.2.2",
-			"resolved": "https://registry.npmmirror.com/eslint-scope/-/eslint-scope-7.2.2.tgz",
-			"integrity": "sha512-dOt21O7lTMhDM+X9mB4GX+DZrZtCUJPL/wlcTqxyrx5IvO0IYtILdtrQGQp+8n5S0gwSVmOf9NQrjMOgfQZlIg==",
+			"version": "8.0.1",
+			"resolved": "https://registry.npmmirror.com/eslint-scope/-/eslint-scope-8.0.1.tgz",
+			"integrity": "sha512-pL8XjgP4ZOmmwfFE8mEhSxA7ZY4C+LWyqjQ3o4yWkkmD0qcMT9kkW3zWHOczhWcjTSgqycYAgwSlXvZltv65og==",
 			"dev": true,
 			"license": "BSD-2-Clause",
 			"dependencies": {
@@ -2068,7 +2046,20 @@
 				"estraverse": "^5.2.0"
 			},
 			"engines": {
-				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/eslint"
+			}
+		},
+		"node_modules/eslint/node_modules/eslint-visitor-keys": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmmirror.com/eslint-visitor-keys/-/eslint-visitor-keys-4.0.0.tgz",
+			"integrity": "sha512-OtIRv/2GyiF6o/d8K7MYKKbXrOUBIK6SfkIRM4Z0dY3w+LiQ0vy3F57m0Z71bjbyeiWFiHJ8brqnmE6H6/jEuw==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"engines": {
+				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
 			},
 			"funding": {
 				"url": "https://opencollective.com/eslint"
@@ -2096,22 +2087,6 @@
 			},
 			"engines": {
 				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/eslint/node_modules/globals": {
-			"version": "13.24.0",
-			"resolved": "https://registry.npmmirror.com/globals/-/globals-13.24.0.tgz",
-			"integrity": "sha512-AhO5QUcj8llrbG09iWhPU2B204J1xnPeL8kQmVorSsy+Sjj1sk8gIyh6cUocGmH4L0UuhAJy+hJMRA4mgA4mFQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"type-fest": "^0.20.2"
-			},
-			"engines": {
-				"node": ">=8"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
@@ -2189,18 +2164,31 @@
 			}
 		},
 		"node_modules/espree": {
-			"version": "9.6.1",
-			"resolved": "https://registry.npmmirror.com/espree/-/espree-9.6.1.tgz",
-			"integrity": "sha512-oruZaFkjorTpF32kDSI5/75ViwGeZginGGy2NoOSg3Q9bnwlnmDm4HLnkl0RE3n+njDXR037aY1+x58Z/zFdwQ==",
+			"version": "10.1.0",
+			"resolved": "https://registry.npmmirror.com/espree/-/espree-10.1.0.tgz",
+			"integrity": "sha512-M1M6CpiE6ffoigIOWYO9UDP8TMUw9kqb21tf+08IgDYjCsOvCuDt4jQcZmoYxx+w7zlKw9/N0KXfto+I8/FrXA==",
 			"dev": true,
 			"license": "BSD-2-Clause",
 			"dependencies": {
-				"acorn": "^8.9.0",
+				"acorn": "^8.12.0",
 				"acorn-jsx": "^5.3.2",
-				"eslint-visitor-keys": "^3.4.1"
+				"eslint-visitor-keys": "^4.0.0"
 			},
 			"engines": {
-				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/eslint"
+			}
+		},
+		"node_modules/espree/node_modules/eslint-visitor-keys": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmmirror.com/eslint-visitor-keys/-/eslint-visitor-keys-4.0.0.tgz",
+			"integrity": "sha512-OtIRv/2GyiF6o/d8K7MYKKbXrOUBIK6SfkIRM4Z0dY3w+LiQ0vy3F57m0Z71bjbyeiWFiHJ8brqnmE6H6/jEuw==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"engines": {
+				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
 			},
 			"funding": {
 				"url": "https://opencollective.com/eslint"
@@ -2375,16 +2363,16 @@
 			}
 		},
 		"node_modules/file-entry-cache": {
-			"version": "6.0.1",
-			"resolved": "https://registry.npmmirror.com/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
-			"integrity": "sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==",
+			"version": "8.0.0",
+			"resolved": "https://registry.npmmirror.com/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
+			"integrity": "sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"flat-cache": "^3.0.4"
+				"flat-cache": "^4.0.0"
 			},
 			"engines": {
-				"node": "^10.12.0 || >=12.0.0"
+				"node": ">=16.0.0"
 			}
 		},
 		"node_modules/fill-range": {
@@ -2425,18 +2413,17 @@
 			}
 		},
 		"node_modules/flat-cache": {
-			"version": "3.2.0",
-			"resolved": "https://registry.npmmirror.com/flat-cache/-/flat-cache-3.2.0.tgz",
-			"integrity": "sha512-CYcENa+FtcUKLmhhqyctpclsq7QF38pKjZHsGNiSQF5r4FtoKDWabFDl3hzaEQMvT1LHEysw5twgLvpYYb4vbw==",
+			"version": "4.0.1",
+			"resolved": "https://registry.npmmirror.com/flat-cache/-/flat-cache-4.0.1.tgz",
+			"integrity": "sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"flatted": "^3.2.9",
-				"keyv": "^4.5.3",
-				"rimraf": "^3.0.2"
+				"keyv": "^4.5.4"
 			},
 			"engines": {
-				"node": "^10.12.0 || >=12.0.0"
+				"node": ">=16"
 			}
 		},
 		"node_modules/flatted": {
@@ -3990,23 +3977,6 @@
 				"node": ">=0.10.0"
 			}
 		},
-		"node_modules/rimraf": {
-			"version": "3.0.2",
-			"resolved": "https://registry.npmmirror.com/rimraf/-/rimraf-3.0.2.tgz",
-			"integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
-			"deprecated": "Rimraf versions prior to v4 are no longer supported",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"glob": "^7.1.3"
-			},
-			"bin": {
-				"rimraf": "bin.js"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/isaacs"
-			}
-		},
 		"node_modules/run-parallel": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmmirror.com/run-parallel/-/run-parallel-1.2.0.tgz",
@@ -4620,19 +4590,6 @@
 			},
 			"engines": {
 				"node": ">= 0.8.0"
-			}
-		},
-		"node_modules/type-fest": {
-			"version": "0.20.2",
-			"resolved": "https://registry.npmmirror.com/type-fest/-/type-fest-0.20.2.tgz",
-			"integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
-			"dev": true,
-			"license": "(MIT OR CC0-1.0)",
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/typed-rest-client": {

--- a/package.json
+++ b/package.json
@@ -585,7 +585,7 @@
 		"@eslint/js": "^9.4.0",
 		"@types/vscode": "^1.82.0",
 		"@vscode/vsce": "^2.27.0",
-		"eslint": "^8.57.0",
+		"eslint": "^9.4.0",
 		"globals": "^15.4.0",
 		"path-browserify": "^1.0.1",
 		"ts-loader": "^9.4.0",
@@ -599,5 +599,6 @@
 		"vscode-languageserver": "^9.0.1",
 		"vscode-languageserver-textdocument": "^1.0.11",
 		"vscode-uri": "^3.0.8"
-	}
+	},
+	"overrides": { "eslint": "^9.4.0" }
 }

--- a/package.json
+++ b/package.json
@@ -580,7 +580,7 @@
     "vscode:prepublish": "webpack --mode production --devtool hidden-source-map",
     "compile": "webpack",
     "compile-cli": "webpack --config webpack.config.cli.js --mode production --devtool hidden-source-map",
-    "eslint": "eslint --fix",
+    "eslint": "eslint . --fix --report-unused-disable-directives --max-warnings 0",
     "watch": "tsc -b -w",
     "watch-web": "webpack --watch",
     "patch": "npm version patch",

--- a/package.json
+++ b/package.json
@@ -585,7 +585,7 @@
 		"@eslint/js": "^9.4.0",
 		"@types/vscode": "^1.82.0",
 		"@vscode/vsce": "^2.27.0",
-		"eslint": "^9.4.0",
+		"eslint": "^8.57.0",
 		"globals": "^15.4.0",
 		"path-browserify": "^1.0.1",
 		"ts-loader": "^9.4.0",

--- a/package.json
+++ b/package.json
@@ -1,603 +1,610 @@
 {
-	"name": "vscode-autohotkey2-lsp",
-	"displayName": "AutoHotkey v2 Language Support",
-	"description": "AutoHotkey v2 Language Support, based on vscode-lsp.",
-	"author": "thqby",
-	"publisher": "thqby",
-	"version": "2.4.6",
-	"license": "LGPLv3.0",
-	"categories": [
-		"Formatters",
-		"Programming Languages",
-		"Snippets"
-	],
-	"keywords": [
-		"ahk",
-		"ahk2",
-		"autohotkey",
-		"autohotkey2"
-	],
-	"repository": {
-		"type": "git",
-		"url": "https://github.com/thqby/vscode-autohotkey2-lsp"
-	},
-	"homepage": "https://github.com/thqby/vscode-autohotkey2-lsp/blob/main/README.md",
-	"icon": "icon.png",
-	"bugs": {
-		"url": "https://github.com/thqby/vscode-autohotkey2-lsp/issues"
-	},
-	"engines": {
-		"vscode": "^1.82.0"
-	},
-	"main": "./client/dist/extension",
-	"browser": "./client/dist/browserClientMain",
-	"contributes": {
-		"breakpoints": [
-			{
-				"language": "ahk2"
-			}
-		],
-		"languages": [
-			{
-				"id": "ahk2",
-				"aliases": [
-					"AutoHotkey2",
-					"autohotkey2",
-					"ahk2"
-				],
-				"extensions": [
-					".ahk",
-					".ah2",
-					".ahk2"
-				],
-				"configuration": "./ahk2.configuration.json",
-				"icon": {
-					"dark": "icon_filetype.png",
-					"light": "icon_filetype.png"
-				}
-			},
-			{ "id": "ahk", "aliases": ["AutoHotkey"] },
-			{ "id": "~ahk2-output" }
-		],
-		"grammars": [
-			{
-				"language": "ahk2",
-				"scopeName": "source.ahk2",
-				"path": "./syntaxes/ahk2.tmLanguage.json",
-				"embeddedLanguages": {
-					"meta.embedded.ahk2": "ahk2"
-				},
-				"unbalancedBracketScopes": [
-					"keyword.keys.ahk2"
-				]
-			},
-			{
-				"language": "~ahk2-output",
-				"scopeName": "ahk2.output",
-				"path": "./syntaxes/ahk2-output.tmLanguage.json"
-			}
-		],
-		"configuration": {
-			"title": "AutoHotkey2",
-			"properties": {
-				"AutoHotkey2.AutoLibInclude": {
-					"scope": "window",
-					"type": "string",
-					"enum": [
-						"Disabled",
-						"Local",
-						"User and Standard",
-						"All"
-					],
-					"default": "Disabled",
-					"description": "%ahk2.autolibinclude%"
-				},
-				"AutoHotkey2.CommentTags": {
-					"scope": "window",
-					"type": "string",
-					"default": "^;;\\s*(?<tag>.+)",
-					"description": "%ahk2.commenttags%"
-				},
-				"AutoHotkey2.CompilerCMD": {
-					"scope": "window",
-					"type": "string",
-					"default": "/compress 0 /base ${execPath}",
-					"markdownDescription": "%ahk2.compilercmd%"
-				},
-				"AutoHotkey2.CompleteFunctionParens": {
-					"scope": "window",
-					"type": "boolean",
-					"default": false,
-					"markdownDescription": "%ahk2.completefunctionparens%"
-				},
-				"AutoHotkey2.DebugConfiguration": {
-					"scope": "window",
-					"type": "object",
-					"default": {
-						"port": "9002-9100",
-						"useAnnounce": "detail",
-						"useAutoJumpToError": true,
-						"useDebugDirective": true,
-						"usePerfTips": true
-					},
-					"description": "%ahk2.debugconfiguration%"
-				},
-				"AutoHotkey2.Diagnostics.ClassStaticMemberCheck": {
-					"scope": "window",
-					"type": "boolean",
-					"default": true,
-					"description": "%ahk2.diagnostics.classstaticmembercheck%"
-				},
-				"AutoHotkey2.Diagnostics.ParamsCheck": {
-					"scope": "window",
-					"type": "boolean",
-					"default": true,
-					"description": "%ahk2.diagnostics.paramscheck%"
-				},
-				"AutoHotkey2.Warn.VarUnset": {
-					"scope": "window",
-					"type": "boolean",
-					"default": true,
-					"description": "%ahk2.warn.varunset%"
-				},
-				"AutoHotkey2.Warn.LocalSameAsGlobal": {
-					"scope": "window",
-					"type": "boolean",
-					"default": false,
-					"description": "%ahk2.warn.localsameasglobal%"
-				},
-				"AutoHotkey2.Warn.CallWithoutParentheses": {
-					"scope": "window",
-					"type": "string",
-					"enum": [
-						"Off",
-						"Parentheses",
-						"On"
-					],
-					"default": "Off",
-					"description": "%ahk2.warn.callwithoutparentheses%"
-				},
-				"AutoHotkey2.ActionWhenV1IsDetected": {
-					"scope": "window",
-					"type": "string",
-					"default": "Warn",
-					"enum": [
-						"Continue",
-						"Warn",
-						"StopParsing",
-						"SwitchToV1",
-						"SkipLine"
-					],
-					"description": "%ahk2.actionwhenv1isdetected%"
-				},
-				"AutoHotkey2.CompletionCommitCharacters": {
-					"scope": "window",
-					"type": "object",
-					"properties": {
-						"Class": {
-							"type": "string"
-						},
-						"Function": {
-							"type": "string"
-						}
-					},
-					"additionalProperties": {
-						"type": "string"
-					},
-					"default": {
-						"Class": ".(",
-						"Function": "("
-					},
-					"markdownDescription": "%ahk2.completioncommitcharacters%"
-				},
-				"AutoHotkey2.Files.Exclude": {
-					"scope": "window",
-					"type": "array",
-					"default": [],
-					"items": {
-						"type": "string"
-					},
-					"uniqueItems": true,
-					"description": "%ahk2.files.exclude%"
-				},
-				"AutoHotkey2.Files.ScanMaxDepth": {
-					"scope": "window",
-					"type": "integer",
-					"default": 2,
-					"description": "%ahk2.files.scanmaxdepth%"
-				},
-				"AutoHotkey2.FormatOptions": {
-					"scope": "window",
-					"type": "object",
-					"properties": {
-						"array_style": {
-							"type": "string",
-							"enum": [
-								"collapse",
-								"expand",
-								"none"
-							],
-							"default": "none"
-						},
-						"brace_style": {
-							"type": "string",
-							"enum": [
-								"One True Brace",
-								"Allman",
-								"One True Brace Variant"
-							],
-							"enumDescriptions": [
-								"if 1 {\n} else {\n}",
-								"if 1\n{\n}\nelse\n{\n}",
-								"if 1 {\n}\nelse {\n}"
-							]
-						},
-						"break_chained_methods": {
-							"type": "boolean",
-							"default": false
-						},
-						"ignore_comment": {
-							"type": "boolean",
-							"default": false
-						},
-						"indent_string": {
-							"type": "string",
-							"default": "\t"
-						},
-						"indent_between_hotif_directive": {
-							"type": "boolean",
-							"default": false
-						},
-						"keyword_start_with_uppercase": {
-							"type": "boolean",
-							"default": false
-						},
-						"max_preserve_newlines": {
-							"type": "number",
-							"default": 2
-						},
-						"object_style": {
-							"type": "string",
-							"enum": [
-								"collapse",
-								"expand",
-								"none"
-							],
-							"default": "none"
-						},
-						"preserve_newlines": {
-							"type": "boolean",
-							"default": true
-						},
-						"space_before_conditional": {
-							"type": "boolean",
-							"default": true
-						},
-						"space_after_double_colon": {
-							"type": "boolean",
-							"default": true
-						},
-						"space_in_empty_paren": {
-							"type": "boolean",
-							"default": false
-						},
-						"space_in_other": {
-							"type": "boolean",
-							"default": true
-						},
-						"space_in_paren": {
-							"type": "boolean",
-							"default": false
-						},
-						"switch_case_alignment": {
-							"type": "boolean",
-							"default": false
-						},
-						"symbol_with_same_case": {
-							"type": "boolean",
-							"default": false
-						},
-						"white_space_before_inline_comment": {
-							"type": "string"
-						},
-						"wrap_line_length": {
-							"type": "number",
-							"default": 0
-						}
-					},
-					"additionalProperties": {
-						"type": "string"
-					},
-					"default": {}
-				},
-				"AutoHotkey2.InterpreterPath": {
-					"scope": "window",
-					"type": "string",
-					"default": "C:\\Program Files\\Autohotkey\\v2\\AutoHotkey.exe",
-					"markdownDescription": "%ahk2.interpreterpath%"
-				},
-				"AutoHotkey2.SymbolFoldingFromOpenBrace": {
-					"scope": "window",
-					"type": "boolean",
-					"default": false,
-					"description": "%ahk2.symbolfoldingfromopenbrace%"
-				},
-				"AutoHotkey2.WorkingDirs": {
-					"scope": "window",
-					"type": "array",
-					"default": [],
-					"items": {
-						"type": "string"
-					},
-					"uniqueItems": true,
-					"description": "%ahk2.workingdirs%"
-				},
-				"AutoHotkey2.Syntaxes": {
-					"scope": "window",
-					"type": "string",
-					"markdownDescription": "%ahk2.syntaxes%"
-				}
-			}
-		},
-		"configurationDefaults": {
-			"[ahk2]": {
-				"editor.defaultFormatter": "thqby.vscode-autohotkey2-lsp",
-				"editor.quickSuggestions": {
-					"other": true,
-					"comments": false,
-					"strings": true
-				}
-			}
-		},
-		"commands": [
-			{
-				"enablement": "editorLangId == ahk2 && shellExecutionSupported",
-				"command": "ahk2.debug",
-				"title": "%ahk2.debug%",
-				"icon": "$(debug)",
-				"category": "ahk2"
-			},
-			{
-				"enablement": "!isWeb",
-				"command": "ahk2.debug.attach",
-				"title": "%ahk2.debug.attach%",
-				"category": "ahk2"
-			},
-			{
-				"enablement": "editorLangId == ahk2 && shellExecutionSupported",
-				"command": "ahk2.debug.params",
-				"title": "%ahk2.debug.params%",
-				"category": "ahk2"
-			},
-			{
-				"enablement": "editorLangId == ahk2",
-				"command": "ahk2.diagnostic.full",
-				"title": "%ahk2.diagnostic.full%",
-				"category": "ahk2"
-			},
-			{
-				"enablement": "editorLangId == ahk2",
-				"command": "ahk2.export.symbols",
-				"title": "%ahk2.export.symbols%",
-				"category": "ahk2"
-			},
-			{
-				"enablement": "editorLangId == ahk2 && shellExecutionSupported",
-				"command": "ahk2.run",
-				"title": "%ahk2.run%",
-				"icon": "$(play)",
-				"category": "ahk2"
-			},
-			{
-				"enablement": "editorLangId == ahk2 && !isWeb",
-				"command": "ahk2.selection.run",
-				"title": "%ahk2.selection.run%",
-				"category": "ahk2"
-			},
-			{
-				"enablement": "editorLangId == ahk2 && !isWeb",
-				"command": "ahk2.stop",
-				"title": "%ahk2.stop%",
-				"icon": "$(stop)",
-				"category": "ahk2"
-			},
-			{
-				"enablement": "editorLangId == ahk2 && shellExecutionSupported",
-				"command": "ahk2.compile",
-				"title": "%ahk2.compile%",
-				"category": "ahk2"
-			},
-			{
-				"enablement": "editorLangId == ahk2 && !isWeb",
-				"command": "ahk2.help",
-				"title": "%ahk2.help%",
-				"category": "ahk2"
-			},
-			{
-				"enablement": "editorLangId == ahk2",
-				"command": "ahk2.generate.comment",
-				"title": "%ahk2.generatecomment%",
-				"category": "ahk2"
-			},
-			{
-				"enablement": "!isWeb",
-				"command": "ahk2.setinterpreter",
-				"title": "%ahk2.setinterpreter%",
-				"category": "ahk2"
-			},
-			{
-				"enablement": "editorLangId == ahk2",
-				"command": "ahk2.updateversioninfo",
-				"title": "%ahk2.updateversioninfo%",
-				"category": "ahk2"
-			},
-			{
-				"enablement": "editorLangId == ahk2 || editorLangId == ahk",
-				"command": "ahk2.switch",
-				"title": "Switch v1/v2",
-				"category": "ahk2"
-			},
-			{
-				"enablement": "editorLangId == ahk2 && !isWeb",
-				"command": "ahk2.selectsyntaxes",
-				"title": "Select syntaxes",
-				"category": "ahk2"
-			},
-			{
-				"enablement": "editorLangId == ahk2 && resourceScheme == file",
-				"command": "ahk2.setscriptdir",
-				"title": "%ahk2.setscriptdir%",
-				"category": "ahk2"
-			}
-		],
-		"menus": {
-			"editor/context": [
-				{
-					"when": "editorLangId == ahk2 && !isWeb",
-					"command": "ahk2.debug",
-					"group": "navigation@1"
-				},
-				{
-					"when": "editorLangId == ahk2 && !isWeb",
-					"command": "ahk2.debug.attach",
-					"group": "navigation@2"
-				},
-				{
-					"when": "editorLangId == ahk2 && !isWeb",
-					"command": "ahk2.debug.params",
-					"group": "navigation@2"
-				},
-				{
-					"when": "editorLangId == ahk2 && !isWeb && editorHasSelection",
-					"command": "ahk2.selection.run",
-					"group": "navigation@0"
-				},
-				{
-					"when": "editorLangId == ahk2 && !isWeb && !editorHasSelection",
-					"command": "ahk2.run",
-					"group": "navigation@0"
-				},
-				{
-					"when": "editorLangId == ahk2 && !isWeb",
-					"command": "ahk2.compile",
-					"group": "navigation@2"
-				},
-				{
-					"when": "editorLangId == ahk2 && !isWeb",
-					"command": "ahk2.help",
-					"group": "navigation@1"
-				},
-				{
-					"when": "editorLangId == ahk2 && !isWeb && ahk2:isRunning",
-					"command": "ahk2.stop",
-					"group": "navigation@0"
-				},
-				{
-					"when": "editorLangId == ahk2",
-					"command": "ahk2.generate.comment",
-					"group": "navigation@2"
-				},
-				{
-					"when": "editorLangId == ahk2",
-					"command": "ahk2.updateversioninfo",
-					"group": "navigation@2"
-				}
-			],
-			"editor/title": [
-				{
-					"command": "ahk2.run",
-					"group": "navigation@0",
-					"when": "resourceLangId == ahk2 && shellExecutionSupported"
-				},
-				{
-					"command": "ahk2.stop",
-					"group": "navigation@0",
-					"when": "resourceLangId == ahk2 && ahk2:isRunning && shellExecutionSupported"
-				},
-				{
-					"command": "ahk2.debug",
-					"group": "navigation@1",
-					"when": "resourceLangId == ahk2 && shellExecutionSupported"
-				}
-			]
-		},
-		"keybindings": [
-			{
-				"command": "ahk2.run",
-				"key": "ctrl+f5",
-				"when": "editorLangId == ahk2 && !isWeb && !editorHasSelection"
-			},
-			{
-				"command": "ahk2.selection.run",
-				"key": "ctrl+f5",
-				"when": "editorLangId == ahk2 && !isWeb && editorHasSelection"
-			},
-			{
-				"command": "ahk2.compile",
-				"key": "ctrl+shift+f5",
-				"when": "editorLangId == ahk2 && !isWeb"
-			},
-			{
-				"command": "ahk2.debug",
-				"key": "f5",
-				"when": "editorLangId == ahk2 && !isWeb && !inDebugMode"
-			},
-			{
-				"command": "ahk2.debug.params",
-				"key": "shift+f5",
-				"when": "editorLangId == ahk2 && !isWeb"
-			},
-			{
-				"command": "ahk2.help",
-				"key": "ctrl+f1",
-				"when": "editorLangId == ahk2 && !isWeb"
-			},
-			{
-				"command": "ahk2.stop",
-				"key": "ctrl+f6",
-				"when": "editorLangId == ahk2 && !isWeb && ahk2:isRunning"
-			}
-		],
-		"semanticTokenScopes": [
-			{
-				"language": "ahk2",
-				"scopes": {
-					"operator": [
-						"keyword.operator.wordlike.ahk2"
-					]
-				}
-			}
-		]
-	},
-	"scripts": {
-		"vscode:prepublish": "webpack --mode production --devtool hidden-source-map",
-		"compile": "webpack",
-		"compile-cli": "webpack --config webpack.config.cli.js --mode production --devtool hidden-source-map",
-		"eslint": "eslint --fix",
-		"watch": "tsc -b -w",
-		"watch-web": "webpack --watch",
-		"patch": "npm version patch",
-		"publish": "vsce publish",
-		"package": "vsce package",
-		"chrome": "vscode-test-web --browserType=chromium --extensionDevelopmentPath=. ./test-data"
-	},
-	"devDependencies": {
-		"@eslint/js": "^9.4.0",
-		"@types/vscode": "^1.82.0",
-		"@vscode/vsce": "^2.27.0",
-		"eslint": "^9.4.0",
-		"globals": "^15.4.0",
-		"path-browserify": "^1.0.1",
-		"ts-loader": "^9.4.0",
-		"typescript": "^5.3.2",
-		"typescript-eslint": "^7.12.0",
-		"webpack": "^5.74.0",
-		"webpack-cli": "^4.10.0"
-	},
-	"dependencies": {
-		"vscode-languageclient": "^9.0.1",
-		"vscode-languageserver": "^9.0.1",
-		"vscode-languageserver-textdocument": "^1.0.11",
-		"vscode-uri": "^3.0.8"
-	}
+  "name": "vscode-autohotkey2-lsp",
+  "displayName": "AutoHotkey v2 Language Support",
+  "description": "AutoHotkey v2 Language Support, based on vscode-lsp.",
+  "author": "thqby",
+  "publisher": "thqby",
+  "version": "2.4.6",
+  "license": "LGPLv3.0",
+  "categories": [
+    "Formatters",
+    "Programming Languages",
+    "Snippets"
+  ],
+  "keywords": [
+    "ahk",
+    "ahk2",
+    "autohotkey",
+    "autohotkey2"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/thqby/vscode-autohotkey2-lsp"
+  },
+  "homepage": "https://github.com/thqby/vscode-autohotkey2-lsp/blob/main/README.md",
+  "icon": "icon.png",
+  "bugs": {
+    "url": "https://github.com/thqby/vscode-autohotkey2-lsp/issues"
+  },
+  "engines": {
+    "vscode": "^1.82.0"
+  },
+  "main": "./client/dist/extension",
+  "browser": "./client/dist/browserClientMain",
+  "contributes": {
+    "breakpoints": [
+      {
+        "language": "ahk2"
+      }
+    ],
+    "languages": [
+      {
+        "id": "ahk2",
+        "aliases": [
+          "AutoHotkey2",
+          "autohotkey2",
+          "ahk2"
+        ],
+        "extensions": [
+          ".ahk",
+          ".ah2",
+          ".ahk2"
+        ],
+        "configuration": "./ahk2.configuration.json",
+        "icon": {
+          "dark": "icon_filetype.png",
+          "light": "icon_filetype.png"
+        }
+      },
+      {
+        "id": "ahk",
+        "aliases": [
+          "AutoHotkey"
+        ]
+      },
+      {
+        "id": "~ahk2-output"
+      }
+    ],
+    "grammars": [
+      {
+        "language": "ahk2",
+        "scopeName": "source.ahk2",
+        "path": "./syntaxes/ahk2.tmLanguage.json",
+        "embeddedLanguages": {
+          "meta.embedded.ahk2": "ahk2"
+        },
+        "unbalancedBracketScopes": [
+          "keyword.keys.ahk2"
+        ]
+      },
+      {
+        "language": "~ahk2-output",
+        "scopeName": "ahk2.output",
+        "path": "./syntaxes/ahk2-output.tmLanguage.json"
+      }
+    ],
+    "configuration": {
+      "title": "AutoHotkey2",
+      "properties": {
+        "AutoHotkey2.AutoLibInclude": {
+          "scope": "window",
+          "type": "string",
+          "enum": [
+            "Disabled",
+            "Local",
+            "User and Standard",
+            "All"
+          ],
+          "default": "Disabled",
+          "description": "%ahk2.autolibinclude%"
+        },
+        "AutoHotkey2.CommentTags": {
+          "scope": "window",
+          "type": "string",
+          "default": "^;;\\s*(?<tag>.+)",
+          "description": "%ahk2.commenttags%"
+        },
+        "AutoHotkey2.CompilerCMD": {
+          "scope": "window",
+          "type": "string",
+          "default": "/compress 0 /base ${execPath}",
+          "markdownDescription": "%ahk2.compilercmd%"
+        },
+        "AutoHotkey2.CompleteFunctionParens": {
+          "scope": "window",
+          "type": "boolean",
+          "default": false,
+          "markdownDescription": "%ahk2.completefunctionparens%"
+        },
+        "AutoHotkey2.DebugConfiguration": {
+          "scope": "window",
+          "type": "object",
+          "default": {
+            "port": "9002-9100",
+            "useAnnounce": "detail",
+            "useAutoJumpToError": true,
+            "useDebugDirective": true,
+            "usePerfTips": true
+          },
+          "description": "%ahk2.debugconfiguration%"
+        },
+        "AutoHotkey2.Diagnostics.ClassStaticMemberCheck": {
+          "scope": "window",
+          "type": "boolean",
+          "default": true,
+          "description": "%ahk2.diagnostics.classstaticmembercheck%"
+        },
+        "AutoHotkey2.Diagnostics.ParamsCheck": {
+          "scope": "window",
+          "type": "boolean",
+          "default": true,
+          "description": "%ahk2.diagnostics.paramscheck%"
+        },
+        "AutoHotkey2.Warn.VarUnset": {
+          "scope": "window",
+          "type": "boolean",
+          "default": true,
+          "description": "%ahk2.warn.varunset%"
+        },
+        "AutoHotkey2.Warn.LocalSameAsGlobal": {
+          "scope": "window",
+          "type": "boolean",
+          "default": false,
+          "description": "%ahk2.warn.localsameasglobal%"
+        },
+        "AutoHotkey2.Warn.CallWithoutParentheses": {
+          "scope": "window",
+          "type": "string",
+          "enum": [
+            "Off",
+            "Parentheses",
+            "On"
+          ],
+          "default": "Off",
+          "description": "%ahk2.warn.callwithoutparentheses%"
+        },
+        "AutoHotkey2.ActionWhenV1IsDetected": {
+          "scope": "window",
+          "type": "string",
+          "default": "Warn",
+          "enum": [
+            "Continue",
+            "Warn",
+            "StopParsing",
+            "SwitchToV1",
+            "SkipLine"
+          ],
+          "description": "%ahk2.actionwhenv1isdetected%"
+        },
+        "AutoHotkey2.CompletionCommitCharacters": {
+          "scope": "window",
+          "type": "object",
+          "properties": {
+            "Class": {
+              "type": "string"
+            },
+            "Function": {
+              "type": "string"
+            }
+          },
+          "additionalProperties": {
+            "type": "string"
+          },
+          "default": {
+            "Class": ".(",
+            "Function": "("
+          },
+          "markdownDescription": "%ahk2.completioncommitcharacters%"
+        },
+        "AutoHotkey2.Files.Exclude": {
+          "scope": "window",
+          "type": "array",
+          "default": [],
+          "items": {
+            "type": "string"
+          },
+          "uniqueItems": true,
+          "description": "%ahk2.files.exclude%"
+        },
+        "AutoHotkey2.Files.ScanMaxDepth": {
+          "scope": "window",
+          "type": "integer",
+          "default": 2,
+          "description": "%ahk2.files.scanmaxdepth%"
+        },
+        "AutoHotkey2.FormatOptions": {
+          "scope": "window",
+          "type": "object",
+          "properties": {
+            "array_style": {
+              "type": "string",
+              "enum": [
+                "collapse",
+                "expand",
+                "none"
+              ],
+              "default": "none"
+            },
+            "brace_style": {
+              "type": "string",
+              "enum": [
+                "One True Brace",
+                "Allman",
+                "One True Brace Variant"
+              ],
+              "enumDescriptions": [
+                "if 1 {\n} else {\n}",
+                "if 1\n{\n}\nelse\n{\n}",
+                "if 1 {\n}\nelse {\n}"
+              ]
+            },
+            "break_chained_methods": {
+              "type": "boolean",
+              "default": false
+            },
+            "ignore_comment": {
+              "type": "boolean",
+              "default": false
+            },
+            "indent_string": {
+              "type": "string",
+              "default": "\t"
+            },
+            "indent_between_hotif_directive": {
+              "type": "boolean",
+              "default": false
+            },
+            "keyword_start_with_uppercase": {
+              "type": "boolean",
+              "default": false
+            },
+            "max_preserve_newlines": {
+              "type": "number",
+              "default": 2
+            },
+            "object_style": {
+              "type": "string",
+              "enum": [
+                "collapse",
+                "expand",
+                "none"
+              ],
+              "default": "none"
+            },
+            "preserve_newlines": {
+              "type": "boolean",
+              "default": true
+            },
+            "space_before_conditional": {
+              "type": "boolean",
+              "default": true
+            },
+            "space_after_double_colon": {
+              "type": "boolean",
+              "default": true
+            },
+            "space_in_empty_paren": {
+              "type": "boolean",
+              "default": false
+            },
+            "space_in_other": {
+              "type": "boolean",
+              "default": true
+            },
+            "space_in_paren": {
+              "type": "boolean",
+              "default": false
+            },
+            "switch_case_alignment": {
+              "type": "boolean",
+              "default": false
+            },
+            "symbol_with_same_case": {
+              "type": "boolean",
+              "default": false
+            },
+            "white_space_before_inline_comment": {
+              "type": "string"
+            },
+            "wrap_line_length": {
+              "type": "number",
+              "default": 0
+            }
+          },
+          "additionalProperties": {
+            "type": "string"
+          },
+          "default": {}
+        },
+        "AutoHotkey2.InterpreterPath": {
+          "scope": "window",
+          "type": "string",
+          "default": "C:\\Program Files\\Autohotkey\\v2\\AutoHotkey.exe",
+          "markdownDescription": "%ahk2.interpreterpath%"
+        },
+        "AutoHotkey2.SymbolFoldingFromOpenBrace": {
+          "scope": "window",
+          "type": "boolean",
+          "default": false,
+          "description": "%ahk2.symbolfoldingfromopenbrace%"
+        },
+        "AutoHotkey2.WorkingDirs": {
+          "scope": "window",
+          "type": "array",
+          "default": [],
+          "items": {
+            "type": "string"
+          },
+          "uniqueItems": true,
+          "description": "%ahk2.workingdirs%"
+        },
+        "AutoHotkey2.Syntaxes": {
+          "scope": "window",
+          "type": "string",
+          "markdownDescription": "%ahk2.syntaxes%"
+        }
+      }
+    },
+    "configurationDefaults": {
+      "[ahk2]": {
+        "editor.defaultFormatter": "thqby.vscode-autohotkey2-lsp",
+        "editor.quickSuggestions": {
+          "other": true,
+          "comments": false,
+          "strings": true
+        }
+      }
+    },
+    "commands": [
+      {
+        "enablement": "editorLangId == ahk2 && shellExecutionSupported",
+        "command": "ahk2.debug",
+        "title": "%ahk2.debug%",
+        "icon": "$(debug)",
+        "category": "ahk2"
+      },
+      {
+        "enablement": "!isWeb",
+        "command": "ahk2.debug.attach",
+        "title": "%ahk2.debug.attach%",
+        "category": "ahk2"
+      },
+      {
+        "enablement": "editorLangId == ahk2 && shellExecutionSupported",
+        "command": "ahk2.debug.params",
+        "title": "%ahk2.debug.params%",
+        "category": "ahk2"
+      },
+      {
+        "enablement": "editorLangId == ahk2",
+        "command": "ahk2.diagnostic.full",
+        "title": "%ahk2.diagnostic.full%",
+        "category": "ahk2"
+      },
+      {
+        "enablement": "editorLangId == ahk2",
+        "command": "ahk2.export.symbols",
+        "title": "%ahk2.export.symbols%",
+        "category": "ahk2"
+      },
+      {
+        "enablement": "editorLangId == ahk2 && shellExecutionSupported",
+        "command": "ahk2.run",
+        "title": "%ahk2.run%",
+        "icon": "$(play)",
+        "category": "ahk2"
+      },
+      {
+        "enablement": "editorLangId == ahk2 && !isWeb",
+        "command": "ahk2.selection.run",
+        "title": "%ahk2.selection.run%",
+        "category": "ahk2"
+      },
+      {
+        "enablement": "editorLangId == ahk2 && !isWeb",
+        "command": "ahk2.stop",
+        "title": "%ahk2.stop%",
+        "icon": "$(stop)",
+        "category": "ahk2"
+      },
+      {
+        "enablement": "editorLangId == ahk2 && shellExecutionSupported",
+        "command": "ahk2.compile",
+        "title": "%ahk2.compile%",
+        "category": "ahk2"
+      },
+      {
+        "enablement": "editorLangId == ahk2 && !isWeb",
+        "command": "ahk2.help",
+        "title": "%ahk2.help%",
+        "category": "ahk2"
+      },
+      {
+        "enablement": "editorLangId == ahk2",
+        "command": "ahk2.generate.comment",
+        "title": "%ahk2.generatecomment%",
+        "category": "ahk2"
+      },
+      {
+        "enablement": "!isWeb",
+        "command": "ahk2.setinterpreter",
+        "title": "%ahk2.setinterpreter%",
+        "category": "ahk2"
+      },
+      {
+        "enablement": "editorLangId == ahk2",
+        "command": "ahk2.updateversioninfo",
+        "title": "%ahk2.updateversioninfo%",
+        "category": "ahk2"
+      },
+      {
+        "enablement": "editorLangId == ahk2 || editorLangId == ahk",
+        "command": "ahk2.switch",
+        "title": "Switch v1/v2",
+        "category": "ahk2"
+      },
+      {
+        "enablement": "editorLangId == ahk2 && !isWeb",
+        "command": "ahk2.selectsyntaxes",
+        "title": "Select syntaxes",
+        "category": "ahk2"
+      },
+      {
+        "enablement": "editorLangId == ahk2 && resourceScheme == file",
+        "command": "ahk2.setscriptdir",
+        "title": "%ahk2.setscriptdir%",
+        "category": "ahk2"
+      }
+    ],
+    "menus": {
+      "editor/context": [
+        {
+          "when": "editorLangId == ahk2 && !isWeb",
+          "command": "ahk2.debug",
+          "group": "navigation@1"
+        },
+        {
+          "when": "editorLangId == ahk2 && !isWeb",
+          "command": "ahk2.debug.attach",
+          "group": "navigation@2"
+        },
+        {
+          "when": "editorLangId == ahk2 && !isWeb",
+          "command": "ahk2.debug.params",
+          "group": "navigation@2"
+        },
+        {
+          "when": "editorLangId == ahk2 && !isWeb && editorHasSelection",
+          "command": "ahk2.selection.run",
+          "group": "navigation@0"
+        },
+        {
+          "when": "editorLangId == ahk2 && !isWeb && !editorHasSelection",
+          "command": "ahk2.run",
+          "group": "navigation@0"
+        },
+        {
+          "when": "editorLangId == ahk2 && !isWeb",
+          "command": "ahk2.compile",
+          "group": "navigation@2"
+        },
+        {
+          "when": "editorLangId == ahk2 && !isWeb",
+          "command": "ahk2.help",
+          "group": "navigation@1"
+        },
+        {
+          "when": "editorLangId == ahk2 && !isWeb && ahk2:isRunning",
+          "command": "ahk2.stop",
+          "group": "navigation@0"
+        },
+        {
+          "when": "editorLangId == ahk2",
+          "command": "ahk2.generate.comment",
+          "group": "navigation@2"
+        },
+        {
+          "when": "editorLangId == ahk2",
+          "command": "ahk2.updateversioninfo",
+          "group": "navigation@2"
+        }
+      ],
+      "editor/title": [
+        {
+          "command": "ahk2.run",
+          "group": "navigation@0",
+          "when": "resourceLangId == ahk2 && shellExecutionSupported"
+        },
+        {
+          "command": "ahk2.stop",
+          "group": "navigation@0",
+          "when": "resourceLangId == ahk2 && ahk2:isRunning && shellExecutionSupported"
+        },
+        {
+          "command": "ahk2.debug",
+          "group": "navigation@1",
+          "when": "resourceLangId == ahk2 && shellExecutionSupported"
+        }
+      ]
+    },
+    "keybindings": [
+      {
+        "command": "ahk2.run",
+        "key": "ctrl+f5",
+        "when": "editorLangId == ahk2 && !isWeb && !editorHasSelection"
+      },
+      {
+        "command": "ahk2.selection.run",
+        "key": "ctrl+f5",
+        "when": "editorLangId == ahk2 && !isWeb && editorHasSelection"
+      },
+      {
+        "command": "ahk2.compile",
+        "key": "ctrl+shift+f5",
+        "when": "editorLangId == ahk2 && !isWeb"
+      },
+      {
+        "command": "ahk2.debug",
+        "key": "f5",
+        "when": "editorLangId == ahk2 && !isWeb && !inDebugMode"
+      },
+      {
+        "command": "ahk2.debug.params",
+        "key": "shift+f5",
+        "when": "editorLangId == ahk2 && !isWeb"
+      },
+      {
+        "command": "ahk2.help",
+        "key": "ctrl+f1",
+        "when": "editorLangId == ahk2 && !isWeb"
+      },
+      {
+        "command": "ahk2.stop",
+        "key": "ctrl+f6",
+        "when": "editorLangId == ahk2 && !isWeb && ahk2:isRunning"
+      }
+    ],
+    "semanticTokenScopes": [
+      {
+        "language": "ahk2",
+        "scopes": {
+          "operator": [
+            "keyword.operator.wordlike.ahk2"
+          ]
+        }
+      }
+    ]
+  },
+  "scripts": {
+    "vscode:prepublish": "webpack --mode production --devtool hidden-source-map",
+    "compile": "webpack",
+    "compile-cli": "webpack --config webpack.config.cli.js --mode production --devtool hidden-source-map",
+    "eslint": "eslint --fix",
+    "watch": "tsc -b -w",
+    "watch-web": "webpack --watch",
+    "patch": "npm version patch",
+    "publish": "vsce publish",
+    "package": "vsce package",
+    "chrome": "vscode-test-web --browserType=chromium --extensionDevelopmentPath=. ./test-data"
+  },
+  "devDependencies": {
+    "@eslint/js": "^9.4.0",
+    "@types/vscode": "^1.82.0",
+    "@vscode/vsce": "^2.27.0",
+    "eslint": "^8.57.0",
+    "globals": "^15.4.0",
+    "path-browserify": "^1.0.1",
+    "ts-loader": "^9.4.0",
+    "typescript": "^5.3.2",
+    "typescript-eslint": "^7.12.0",
+    "webpack": "^5.74.0",
+    "webpack-cli": "^4.10.0"
+  },
+  "dependencies": {
+    "vscode-languageclient": "^9.0.1",
+    "vscode-languageserver": "^9.0.1",
+    "vscode-languageserver-textdocument": "^1.0.11",
+    "vscode-uri": "^3.0.8"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -573,7 +573,7 @@
 		"vscode:prepublish": "webpack --mode production --devtool hidden-source-map",
 		"compile": "webpack",
 		"compile-cli": "webpack --config webpack.config.cli.js --mode production --devtool hidden-source-map",
-		"eslint": "eslint --fix",
+		"eslint": "eslint . --fix --report-unused-disable-directives --max-warnings 0",
 		"watch": "tsc -b -w",
 		"watch-web": "webpack --watch",
 		"patch": "npm version patch",

--- a/package.json
+++ b/package.json
@@ -1,610 +1,603 @@
 {
-  "name": "vscode-autohotkey2-lsp",
-  "displayName": "AutoHotkey v2 Language Support",
-  "description": "AutoHotkey v2 Language Support, based on vscode-lsp.",
-  "author": "thqby",
-  "publisher": "thqby",
-  "version": "2.4.6",
-  "license": "LGPLv3.0",
-  "categories": [
-    "Formatters",
-    "Programming Languages",
-    "Snippets"
-  ],
-  "keywords": [
-    "ahk",
-    "ahk2",
-    "autohotkey",
-    "autohotkey2"
-  ],
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/thqby/vscode-autohotkey2-lsp"
-  },
-  "homepage": "https://github.com/thqby/vscode-autohotkey2-lsp/blob/main/README.md",
-  "icon": "icon.png",
-  "bugs": {
-    "url": "https://github.com/thqby/vscode-autohotkey2-lsp/issues"
-  },
-  "engines": {
-    "vscode": "^1.82.0"
-  },
-  "main": "./client/dist/extension",
-  "browser": "./client/dist/browserClientMain",
-  "contributes": {
-    "breakpoints": [
-      {
-        "language": "ahk2"
-      }
-    ],
-    "languages": [
-      {
-        "id": "ahk2",
-        "aliases": [
-          "AutoHotkey2",
-          "autohotkey2",
-          "ahk2"
-        ],
-        "extensions": [
-          ".ahk",
-          ".ah2",
-          ".ahk2"
-        ],
-        "configuration": "./ahk2.configuration.json",
-        "icon": {
-          "dark": "icon_filetype.png",
-          "light": "icon_filetype.png"
-        }
-      },
-      {
-        "id": "ahk",
-        "aliases": [
-          "AutoHotkey"
-        ]
-      },
-      {
-        "id": "~ahk2-output"
-      }
-    ],
-    "grammars": [
-      {
-        "language": "ahk2",
-        "scopeName": "source.ahk2",
-        "path": "./syntaxes/ahk2.tmLanguage.json",
-        "embeddedLanguages": {
-          "meta.embedded.ahk2": "ahk2"
-        },
-        "unbalancedBracketScopes": [
-          "keyword.keys.ahk2"
-        ]
-      },
-      {
-        "language": "~ahk2-output",
-        "scopeName": "ahk2.output",
-        "path": "./syntaxes/ahk2-output.tmLanguage.json"
-      }
-    ],
-    "configuration": {
-      "title": "AutoHotkey2",
-      "properties": {
-        "AutoHotkey2.AutoLibInclude": {
-          "scope": "window",
-          "type": "string",
-          "enum": [
-            "Disabled",
-            "Local",
-            "User and Standard",
-            "All"
-          ],
-          "default": "Disabled",
-          "description": "%ahk2.autolibinclude%"
-        },
-        "AutoHotkey2.CommentTags": {
-          "scope": "window",
-          "type": "string",
-          "default": "^;;\\s*(?<tag>.+)",
-          "description": "%ahk2.commenttags%"
-        },
-        "AutoHotkey2.CompilerCMD": {
-          "scope": "window",
-          "type": "string",
-          "default": "/compress 0 /base ${execPath}",
-          "markdownDescription": "%ahk2.compilercmd%"
-        },
-        "AutoHotkey2.CompleteFunctionParens": {
-          "scope": "window",
-          "type": "boolean",
-          "default": false,
-          "markdownDescription": "%ahk2.completefunctionparens%"
-        },
-        "AutoHotkey2.DebugConfiguration": {
-          "scope": "window",
-          "type": "object",
-          "default": {
-            "port": "9002-9100",
-            "useAnnounce": "detail",
-            "useAutoJumpToError": true,
-            "useDebugDirective": true,
-            "usePerfTips": true
-          },
-          "description": "%ahk2.debugconfiguration%"
-        },
-        "AutoHotkey2.Diagnostics.ClassStaticMemberCheck": {
-          "scope": "window",
-          "type": "boolean",
-          "default": true,
-          "description": "%ahk2.diagnostics.classstaticmembercheck%"
-        },
-        "AutoHotkey2.Diagnostics.ParamsCheck": {
-          "scope": "window",
-          "type": "boolean",
-          "default": true,
-          "description": "%ahk2.diagnostics.paramscheck%"
-        },
-        "AutoHotkey2.Warn.VarUnset": {
-          "scope": "window",
-          "type": "boolean",
-          "default": true,
-          "description": "%ahk2.warn.varunset%"
-        },
-        "AutoHotkey2.Warn.LocalSameAsGlobal": {
-          "scope": "window",
-          "type": "boolean",
-          "default": false,
-          "description": "%ahk2.warn.localsameasglobal%"
-        },
-        "AutoHotkey2.Warn.CallWithoutParentheses": {
-          "scope": "window",
-          "type": "string",
-          "enum": [
-            "Off",
-            "Parentheses",
-            "On"
-          ],
-          "default": "Off",
-          "description": "%ahk2.warn.callwithoutparentheses%"
-        },
-        "AutoHotkey2.ActionWhenV1IsDetected": {
-          "scope": "window",
-          "type": "string",
-          "default": "Warn",
-          "enum": [
-            "Continue",
-            "Warn",
-            "StopParsing",
-            "SwitchToV1",
-            "SkipLine"
-          ],
-          "description": "%ahk2.actionwhenv1isdetected%"
-        },
-        "AutoHotkey2.CompletionCommitCharacters": {
-          "scope": "window",
-          "type": "object",
-          "properties": {
-            "Class": {
-              "type": "string"
-            },
-            "Function": {
-              "type": "string"
-            }
-          },
-          "additionalProperties": {
-            "type": "string"
-          },
-          "default": {
-            "Class": ".(",
-            "Function": "("
-          },
-          "markdownDescription": "%ahk2.completioncommitcharacters%"
-        },
-        "AutoHotkey2.Files.Exclude": {
-          "scope": "window",
-          "type": "array",
-          "default": [],
-          "items": {
-            "type": "string"
-          },
-          "uniqueItems": true,
-          "description": "%ahk2.files.exclude%"
-        },
-        "AutoHotkey2.Files.ScanMaxDepth": {
-          "scope": "window",
-          "type": "integer",
-          "default": 2,
-          "description": "%ahk2.files.scanmaxdepth%"
-        },
-        "AutoHotkey2.FormatOptions": {
-          "scope": "window",
-          "type": "object",
-          "properties": {
-            "array_style": {
-              "type": "string",
-              "enum": [
-                "collapse",
-                "expand",
-                "none"
-              ],
-              "default": "none"
-            },
-            "brace_style": {
-              "type": "string",
-              "enum": [
-                "One True Brace",
-                "Allman",
-                "One True Brace Variant"
-              ],
-              "enumDescriptions": [
-                "if 1 {\n} else {\n}",
-                "if 1\n{\n}\nelse\n{\n}",
-                "if 1 {\n}\nelse {\n}"
-              ]
-            },
-            "break_chained_methods": {
-              "type": "boolean",
-              "default": false
-            },
-            "ignore_comment": {
-              "type": "boolean",
-              "default": false
-            },
-            "indent_string": {
-              "type": "string",
-              "default": "\t"
-            },
-            "indent_between_hotif_directive": {
-              "type": "boolean",
-              "default": false
-            },
-            "keyword_start_with_uppercase": {
-              "type": "boolean",
-              "default": false
-            },
-            "max_preserve_newlines": {
-              "type": "number",
-              "default": 2
-            },
-            "object_style": {
-              "type": "string",
-              "enum": [
-                "collapse",
-                "expand",
-                "none"
-              ],
-              "default": "none"
-            },
-            "preserve_newlines": {
-              "type": "boolean",
-              "default": true
-            },
-            "space_before_conditional": {
-              "type": "boolean",
-              "default": true
-            },
-            "space_after_double_colon": {
-              "type": "boolean",
-              "default": true
-            },
-            "space_in_empty_paren": {
-              "type": "boolean",
-              "default": false
-            },
-            "space_in_other": {
-              "type": "boolean",
-              "default": true
-            },
-            "space_in_paren": {
-              "type": "boolean",
-              "default": false
-            },
-            "switch_case_alignment": {
-              "type": "boolean",
-              "default": false
-            },
-            "symbol_with_same_case": {
-              "type": "boolean",
-              "default": false
-            },
-            "white_space_before_inline_comment": {
-              "type": "string"
-            },
-            "wrap_line_length": {
-              "type": "number",
-              "default": 0
-            }
-          },
-          "additionalProperties": {
-            "type": "string"
-          },
-          "default": {}
-        },
-        "AutoHotkey2.InterpreterPath": {
-          "scope": "window",
-          "type": "string",
-          "default": "C:\\Program Files\\Autohotkey\\v2\\AutoHotkey.exe",
-          "markdownDescription": "%ahk2.interpreterpath%"
-        },
-        "AutoHotkey2.SymbolFoldingFromOpenBrace": {
-          "scope": "window",
-          "type": "boolean",
-          "default": false,
-          "description": "%ahk2.symbolfoldingfromopenbrace%"
-        },
-        "AutoHotkey2.WorkingDirs": {
-          "scope": "window",
-          "type": "array",
-          "default": [],
-          "items": {
-            "type": "string"
-          },
-          "uniqueItems": true,
-          "description": "%ahk2.workingdirs%"
-        },
-        "AutoHotkey2.Syntaxes": {
-          "scope": "window",
-          "type": "string",
-          "markdownDescription": "%ahk2.syntaxes%"
-        }
-      }
-    },
-    "configurationDefaults": {
-      "[ahk2]": {
-        "editor.defaultFormatter": "thqby.vscode-autohotkey2-lsp",
-        "editor.quickSuggestions": {
-          "other": true,
-          "comments": false,
-          "strings": true
-        }
-      }
-    },
-    "commands": [
-      {
-        "enablement": "editorLangId == ahk2 && shellExecutionSupported",
-        "command": "ahk2.debug",
-        "title": "%ahk2.debug%",
-        "icon": "$(debug)",
-        "category": "ahk2"
-      },
-      {
-        "enablement": "!isWeb",
-        "command": "ahk2.debug.attach",
-        "title": "%ahk2.debug.attach%",
-        "category": "ahk2"
-      },
-      {
-        "enablement": "editorLangId == ahk2 && shellExecutionSupported",
-        "command": "ahk2.debug.params",
-        "title": "%ahk2.debug.params%",
-        "category": "ahk2"
-      },
-      {
-        "enablement": "editorLangId == ahk2",
-        "command": "ahk2.diagnostic.full",
-        "title": "%ahk2.diagnostic.full%",
-        "category": "ahk2"
-      },
-      {
-        "enablement": "editorLangId == ahk2",
-        "command": "ahk2.export.symbols",
-        "title": "%ahk2.export.symbols%",
-        "category": "ahk2"
-      },
-      {
-        "enablement": "editorLangId == ahk2 && shellExecutionSupported",
-        "command": "ahk2.run",
-        "title": "%ahk2.run%",
-        "icon": "$(play)",
-        "category": "ahk2"
-      },
-      {
-        "enablement": "editorLangId == ahk2 && !isWeb",
-        "command": "ahk2.selection.run",
-        "title": "%ahk2.selection.run%",
-        "category": "ahk2"
-      },
-      {
-        "enablement": "editorLangId == ahk2 && !isWeb",
-        "command": "ahk2.stop",
-        "title": "%ahk2.stop%",
-        "icon": "$(stop)",
-        "category": "ahk2"
-      },
-      {
-        "enablement": "editorLangId == ahk2 && shellExecutionSupported",
-        "command": "ahk2.compile",
-        "title": "%ahk2.compile%",
-        "category": "ahk2"
-      },
-      {
-        "enablement": "editorLangId == ahk2 && !isWeb",
-        "command": "ahk2.help",
-        "title": "%ahk2.help%",
-        "category": "ahk2"
-      },
-      {
-        "enablement": "editorLangId == ahk2",
-        "command": "ahk2.generate.comment",
-        "title": "%ahk2.generatecomment%",
-        "category": "ahk2"
-      },
-      {
-        "enablement": "!isWeb",
-        "command": "ahk2.setinterpreter",
-        "title": "%ahk2.setinterpreter%",
-        "category": "ahk2"
-      },
-      {
-        "enablement": "editorLangId == ahk2",
-        "command": "ahk2.updateversioninfo",
-        "title": "%ahk2.updateversioninfo%",
-        "category": "ahk2"
-      },
-      {
-        "enablement": "editorLangId == ahk2 || editorLangId == ahk",
-        "command": "ahk2.switch",
-        "title": "Switch v1/v2",
-        "category": "ahk2"
-      },
-      {
-        "enablement": "editorLangId == ahk2 && !isWeb",
-        "command": "ahk2.selectsyntaxes",
-        "title": "Select syntaxes",
-        "category": "ahk2"
-      },
-      {
-        "enablement": "editorLangId == ahk2 && resourceScheme == file",
-        "command": "ahk2.setscriptdir",
-        "title": "%ahk2.setscriptdir%",
-        "category": "ahk2"
-      }
-    ],
-    "menus": {
-      "editor/context": [
-        {
-          "when": "editorLangId == ahk2 && !isWeb",
-          "command": "ahk2.debug",
-          "group": "navigation@1"
-        },
-        {
-          "when": "editorLangId == ahk2 && !isWeb",
-          "command": "ahk2.debug.attach",
-          "group": "navigation@2"
-        },
-        {
-          "when": "editorLangId == ahk2 && !isWeb",
-          "command": "ahk2.debug.params",
-          "group": "navigation@2"
-        },
-        {
-          "when": "editorLangId == ahk2 && !isWeb && editorHasSelection",
-          "command": "ahk2.selection.run",
-          "group": "navigation@0"
-        },
-        {
-          "when": "editorLangId == ahk2 && !isWeb && !editorHasSelection",
-          "command": "ahk2.run",
-          "group": "navigation@0"
-        },
-        {
-          "when": "editorLangId == ahk2 && !isWeb",
-          "command": "ahk2.compile",
-          "group": "navigation@2"
-        },
-        {
-          "when": "editorLangId == ahk2 && !isWeb",
-          "command": "ahk2.help",
-          "group": "navigation@1"
-        },
-        {
-          "when": "editorLangId == ahk2 && !isWeb && ahk2:isRunning",
-          "command": "ahk2.stop",
-          "group": "navigation@0"
-        },
-        {
-          "when": "editorLangId == ahk2",
-          "command": "ahk2.generate.comment",
-          "group": "navigation@2"
-        },
-        {
-          "when": "editorLangId == ahk2",
-          "command": "ahk2.updateversioninfo",
-          "group": "navigation@2"
-        }
-      ],
-      "editor/title": [
-        {
-          "command": "ahk2.run",
-          "group": "navigation@0",
-          "when": "resourceLangId == ahk2 && shellExecutionSupported"
-        },
-        {
-          "command": "ahk2.stop",
-          "group": "navigation@0",
-          "when": "resourceLangId == ahk2 && ahk2:isRunning && shellExecutionSupported"
-        },
-        {
-          "command": "ahk2.debug",
-          "group": "navigation@1",
-          "when": "resourceLangId == ahk2 && shellExecutionSupported"
-        }
-      ]
-    },
-    "keybindings": [
-      {
-        "command": "ahk2.run",
-        "key": "ctrl+f5",
-        "when": "editorLangId == ahk2 && !isWeb && !editorHasSelection"
-      },
-      {
-        "command": "ahk2.selection.run",
-        "key": "ctrl+f5",
-        "when": "editorLangId == ahk2 && !isWeb && editorHasSelection"
-      },
-      {
-        "command": "ahk2.compile",
-        "key": "ctrl+shift+f5",
-        "when": "editorLangId == ahk2 && !isWeb"
-      },
-      {
-        "command": "ahk2.debug",
-        "key": "f5",
-        "when": "editorLangId == ahk2 && !isWeb && !inDebugMode"
-      },
-      {
-        "command": "ahk2.debug.params",
-        "key": "shift+f5",
-        "when": "editorLangId == ahk2 && !isWeb"
-      },
-      {
-        "command": "ahk2.help",
-        "key": "ctrl+f1",
-        "when": "editorLangId == ahk2 && !isWeb"
-      },
-      {
-        "command": "ahk2.stop",
-        "key": "ctrl+f6",
-        "when": "editorLangId == ahk2 && !isWeb && ahk2:isRunning"
-      }
-    ],
-    "semanticTokenScopes": [
-      {
-        "language": "ahk2",
-        "scopes": {
-          "operator": [
-            "keyword.operator.wordlike.ahk2"
-          ]
-        }
-      }
-    ]
-  },
-  "scripts": {
-    "vscode:prepublish": "webpack --mode production --devtool hidden-source-map",
-    "compile": "webpack",
-    "compile-cli": "webpack --config webpack.config.cli.js --mode production --devtool hidden-source-map",
-    "eslint": "eslint . --fix --report-unused-disable-directives --max-warnings 0",
-    "watch": "tsc -b -w",
-    "watch-web": "webpack --watch",
-    "patch": "npm version patch",
-    "publish": "vsce publish",
-    "package": "vsce package",
-    "chrome": "vscode-test-web --browserType=chromium --extensionDevelopmentPath=. ./test-data"
-  },
-  "devDependencies": {
-    "@eslint/js": "^9.4.0",
-    "@types/vscode": "^1.82.0",
-    "@vscode/vsce": "^2.27.0",
-    "eslint": "^8.57.0",
-    "globals": "^15.4.0",
-    "path-browserify": "^1.0.1",
-    "ts-loader": "^9.4.0",
-    "typescript": "^5.3.2",
-    "typescript-eslint": "^7.12.0",
-    "webpack": "^5.74.0",
-    "webpack-cli": "^4.10.0"
-  },
-  "dependencies": {
-    "vscode-languageclient": "^9.0.1",
-    "vscode-languageserver": "^9.0.1",
-    "vscode-languageserver-textdocument": "^1.0.11",
-    "vscode-uri": "^3.0.8"
-  }
+	"name": "vscode-autohotkey2-lsp",
+	"displayName": "AutoHotkey v2 Language Support",
+	"description": "AutoHotkey v2 Language Support, based on vscode-lsp.",
+	"author": "thqby",
+	"publisher": "thqby",
+	"version": "2.4.6",
+	"license": "LGPLv3.0",
+	"categories": [
+		"Formatters",
+		"Programming Languages",
+		"Snippets"
+	],
+	"keywords": [
+		"ahk",
+		"ahk2",
+		"autohotkey",
+		"autohotkey2"
+	],
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/thqby/vscode-autohotkey2-lsp"
+	},
+	"homepage": "https://github.com/thqby/vscode-autohotkey2-lsp/blob/main/README.md",
+	"icon": "icon.png",
+	"bugs": {
+		"url": "https://github.com/thqby/vscode-autohotkey2-lsp/issues"
+	},
+	"engines": {
+		"vscode": "^1.82.0"
+	},
+	"main": "./client/dist/extension",
+	"browser": "./client/dist/browserClientMain",
+	"contributes": {
+		"breakpoints": [
+			{
+				"language": "ahk2"
+			}
+		],
+		"languages": [
+			{
+				"id": "ahk2",
+				"aliases": [
+					"AutoHotkey2",
+					"autohotkey2",
+					"ahk2"
+				],
+				"extensions": [
+					".ahk",
+					".ah2",
+					".ahk2"
+				],
+				"configuration": "./ahk2.configuration.json",
+				"icon": {
+					"dark": "icon_filetype.png",
+					"light": "icon_filetype.png"
+				}
+			},
+			{ "id": "ahk", "aliases": ["AutoHotkey"] },
+			{ "id": "~ahk2-output" }
+		],
+		"grammars": [
+			{
+				"language": "ahk2",
+				"scopeName": "source.ahk2",
+				"path": "./syntaxes/ahk2.tmLanguage.json",
+				"embeddedLanguages": {
+					"meta.embedded.ahk2": "ahk2"
+				},
+				"unbalancedBracketScopes": [
+					"keyword.keys.ahk2"
+				]
+			},
+			{
+				"language": "~ahk2-output",
+				"scopeName": "ahk2.output",
+				"path": "./syntaxes/ahk2-output.tmLanguage.json"
+			}
+		],
+		"configuration": {
+			"title": "AutoHotkey2",
+			"properties": {
+				"AutoHotkey2.AutoLibInclude": {
+					"scope": "window",
+					"type": "string",
+					"enum": [
+						"Disabled",
+						"Local",
+						"User and Standard",
+						"All"
+					],
+					"default": "Disabled",
+					"description": "%ahk2.autolibinclude%"
+				},
+				"AutoHotkey2.CommentTags": {
+					"scope": "window",
+					"type": "string",
+					"default": "^;;\\s*(?<tag>.+)",
+					"description": "%ahk2.commenttags%"
+				},
+				"AutoHotkey2.CompilerCMD": {
+					"scope": "window",
+					"type": "string",
+					"default": "/compress 0 /base ${execPath}",
+					"markdownDescription": "%ahk2.compilercmd%"
+				},
+				"AutoHotkey2.CompleteFunctionParens": {
+					"scope": "window",
+					"type": "boolean",
+					"default": false,
+					"markdownDescription": "%ahk2.completefunctionparens%"
+				},
+				"AutoHotkey2.DebugConfiguration": {
+					"scope": "window",
+					"type": "object",
+					"default": {
+						"port": "9002-9100",
+						"useAnnounce": "detail",
+						"useAutoJumpToError": true,
+						"useDebugDirective": true,
+						"usePerfTips": true
+					},
+					"description": "%ahk2.debugconfiguration%"
+				},
+				"AutoHotkey2.Diagnostics.ClassStaticMemberCheck": {
+					"scope": "window",
+					"type": "boolean",
+					"default": true,
+					"description": "%ahk2.diagnostics.classstaticmembercheck%"
+				},
+				"AutoHotkey2.Diagnostics.ParamsCheck": {
+					"scope": "window",
+					"type": "boolean",
+					"default": true,
+					"description": "%ahk2.diagnostics.paramscheck%"
+				},
+				"AutoHotkey2.Warn.VarUnset": {
+					"scope": "window",
+					"type": "boolean",
+					"default": true,
+					"description": "%ahk2.warn.varunset%"
+				},
+				"AutoHotkey2.Warn.LocalSameAsGlobal": {
+					"scope": "window",
+					"type": "boolean",
+					"default": false,
+					"description": "%ahk2.warn.localsameasglobal%"
+				},
+				"AutoHotkey2.Warn.CallWithoutParentheses": {
+					"scope": "window",
+					"type": "string",
+					"enum": [
+						"Off",
+						"Parentheses",
+						"On"
+					],
+					"default": "Off",
+					"description": "%ahk2.warn.callwithoutparentheses%"
+				},
+				"AutoHotkey2.ActionWhenV1IsDetected": {
+					"scope": "window",
+					"type": "string",
+					"default": "Warn",
+					"enum": [
+						"Continue",
+						"Warn",
+						"StopParsing",
+						"SwitchToV1",
+						"SkipLine"
+					],
+					"description": "%ahk2.actionwhenv1isdetected%"
+				},
+				"AutoHotkey2.CompletionCommitCharacters": {
+					"scope": "window",
+					"type": "object",
+					"properties": {
+						"Class": {
+							"type": "string"
+						},
+						"Function": {
+							"type": "string"
+						}
+					},
+					"additionalProperties": {
+						"type": "string"
+					},
+					"default": {
+						"Class": ".(",
+						"Function": "("
+					},
+					"markdownDescription": "%ahk2.completioncommitcharacters%"
+				},
+				"AutoHotkey2.Files.Exclude": {
+					"scope": "window",
+					"type": "array",
+					"default": [],
+					"items": {
+						"type": "string"
+					},
+					"uniqueItems": true,
+					"description": "%ahk2.files.exclude%"
+				},
+				"AutoHotkey2.Files.ScanMaxDepth": {
+					"scope": "window",
+					"type": "integer",
+					"default": 2,
+					"description": "%ahk2.files.scanmaxdepth%"
+				},
+				"AutoHotkey2.FormatOptions": {
+					"scope": "window",
+					"type": "object",
+					"properties": {
+						"array_style": {
+							"type": "string",
+							"enum": [
+								"collapse",
+								"expand",
+								"none"
+							],
+							"default": "none"
+						},
+						"brace_style": {
+							"type": "string",
+							"enum": [
+								"One True Brace",
+								"Allman",
+								"One True Brace Variant"
+							],
+							"enumDescriptions": [
+								"if 1 {\n} else {\n}",
+								"if 1\n{\n}\nelse\n{\n}",
+								"if 1 {\n}\nelse {\n}"
+							]
+						},
+						"break_chained_methods": {
+							"type": "boolean",
+							"default": false
+						},
+						"ignore_comment": {
+							"type": "boolean",
+							"default": false
+						},
+						"indent_string": {
+							"type": "string",
+							"default": "\t"
+						},
+						"indent_between_hotif_directive": {
+							"type": "boolean",
+							"default": false
+						},
+						"keyword_start_with_uppercase": {
+							"type": "boolean",
+							"default": false
+						},
+						"max_preserve_newlines": {
+							"type": "number",
+							"default": 2
+						},
+						"object_style": {
+							"type": "string",
+							"enum": [
+								"collapse",
+								"expand",
+								"none"
+							],
+							"default": "none"
+						},
+						"preserve_newlines": {
+							"type": "boolean",
+							"default": true
+						},
+						"space_before_conditional": {
+							"type": "boolean",
+							"default": true
+						},
+						"space_after_double_colon": {
+							"type": "boolean",
+							"default": true
+						},
+						"space_in_empty_paren": {
+							"type": "boolean",
+							"default": false
+						},
+						"space_in_other": {
+							"type": "boolean",
+							"default": true
+						},
+						"space_in_paren": {
+							"type": "boolean",
+							"default": false
+						},
+						"switch_case_alignment": {
+							"type": "boolean",
+							"default": false
+						},
+						"symbol_with_same_case": {
+							"type": "boolean",
+							"default": false
+						},
+						"white_space_before_inline_comment": {
+							"type": "string"
+						},
+						"wrap_line_length": {
+							"type": "number",
+							"default": 0
+						}
+					},
+					"additionalProperties": {
+						"type": "string"
+					},
+					"default": {}
+				},
+				"AutoHotkey2.InterpreterPath": {
+					"scope": "window",
+					"type": "string",
+					"default": "C:\\Program Files\\Autohotkey\\v2\\AutoHotkey.exe",
+					"markdownDescription": "%ahk2.interpreterpath%"
+				},
+				"AutoHotkey2.SymbolFoldingFromOpenBrace": {
+					"scope": "window",
+					"type": "boolean",
+					"default": false,
+					"description": "%ahk2.symbolfoldingfromopenbrace%"
+				},
+				"AutoHotkey2.WorkingDirs": {
+					"scope": "window",
+					"type": "array",
+					"default": [],
+					"items": {
+						"type": "string"
+					},
+					"uniqueItems": true,
+					"description": "%ahk2.workingdirs%"
+				},
+				"AutoHotkey2.Syntaxes": {
+					"scope": "window",
+					"type": "string",
+					"markdownDescription": "%ahk2.syntaxes%"
+				}
+			}
+		},
+		"configurationDefaults": {
+			"[ahk2]": {
+				"editor.defaultFormatter": "thqby.vscode-autohotkey2-lsp",
+				"editor.quickSuggestions": {
+					"other": true,
+					"comments": false,
+					"strings": true
+				}
+			}
+		},
+		"commands": [
+			{
+				"enablement": "editorLangId == ahk2 && shellExecutionSupported",
+				"command": "ahk2.debug",
+				"title": "%ahk2.debug%",
+				"icon": "$(debug)",
+				"category": "ahk2"
+			},
+			{
+				"enablement": "!isWeb",
+				"command": "ahk2.debug.attach",
+				"title": "%ahk2.debug.attach%",
+				"category": "ahk2"
+			},
+			{
+				"enablement": "editorLangId == ahk2 && shellExecutionSupported",
+				"command": "ahk2.debug.params",
+				"title": "%ahk2.debug.params%",
+				"category": "ahk2"
+			},
+			{
+				"enablement": "editorLangId == ahk2",
+				"command": "ahk2.diagnostic.full",
+				"title": "%ahk2.diagnostic.full%",
+				"category": "ahk2"
+			},
+			{
+				"enablement": "editorLangId == ahk2",
+				"command": "ahk2.export.symbols",
+				"title": "%ahk2.export.symbols%",
+				"category": "ahk2"
+			},
+			{
+				"enablement": "editorLangId == ahk2 && shellExecutionSupported",
+				"command": "ahk2.run",
+				"title": "%ahk2.run%",
+				"icon": "$(play)",
+				"category": "ahk2"
+			},
+			{
+				"enablement": "editorLangId == ahk2 && !isWeb",
+				"command": "ahk2.selection.run",
+				"title": "%ahk2.selection.run%",
+				"category": "ahk2"
+			},
+			{
+				"enablement": "editorLangId == ahk2 && !isWeb",
+				"command": "ahk2.stop",
+				"title": "%ahk2.stop%",
+				"icon": "$(stop)",
+				"category": "ahk2"
+			},
+			{
+				"enablement": "editorLangId == ahk2 && shellExecutionSupported",
+				"command": "ahk2.compile",
+				"title": "%ahk2.compile%",
+				"category": "ahk2"
+			},
+			{
+				"enablement": "editorLangId == ahk2 && !isWeb",
+				"command": "ahk2.help",
+				"title": "%ahk2.help%",
+				"category": "ahk2"
+			},
+			{
+				"enablement": "editorLangId == ahk2",
+				"command": "ahk2.generate.comment",
+				"title": "%ahk2.generatecomment%",
+				"category": "ahk2"
+			},
+			{
+				"enablement": "!isWeb",
+				"command": "ahk2.setinterpreter",
+				"title": "%ahk2.setinterpreter%",
+				"category": "ahk2"
+			},
+			{
+				"enablement": "editorLangId == ahk2",
+				"command": "ahk2.updateversioninfo",
+				"title": "%ahk2.updateversioninfo%",
+				"category": "ahk2"
+			},
+			{
+				"enablement": "editorLangId == ahk2 || editorLangId == ahk",
+				"command": "ahk2.switch",
+				"title": "Switch v1/v2",
+				"category": "ahk2"
+			},
+			{
+				"enablement": "editorLangId == ahk2 && !isWeb",
+				"command": "ahk2.selectsyntaxes",
+				"title": "Select syntaxes",
+				"category": "ahk2"
+			},
+			{
+				"enablement": "editorLangId == ahk2 && resourceScheme == file",
+				"command": "ahk2.setscriptdir",
+				"title": "%ahk2.setscriptdir%",
+				"category": "ahk2"
+			}
+		],
+		"menus": {
+			"editor/context": [
+				{
+					"when": "editorLangId == ahk2 && !isWeb",
+					"command": "ahk2.debug",
+					"group": "navigation@1"
+				},
+				{
+					"when": "editorLangId == ahk2 && !isWeb",
+					"command": "ahk2.debug.attach",
+					"group": "navigation@2"
+				},
+				{
+					"when": "editorLangId == ahk2 && !isWeb",
+					"command": "ahk2.debug.params",
+					"group": "navigation@2"
+				},
+				{
+					"when": "editorLangId == ahk2 && !isWeb && editorHasSelection",
+					"command": "ahk2.selection.run",
+					"group": "navigation@0"
+				},
+				{
+					"when": "editorLangId == ahk2 && !isWeb && !editorHasSelection",
+					"command": "ahk2.run",
+					"group": "navigation@0"
+				},
+				{
+					"when": "editorLangId == ahk2 && !isWeb",
+					"command": "ahk2.compile",
+					"group": "navigation@2"
+				},
+				{
+					"when": "editorLangId == ahk2 && !isWeb",
+					"command": "ahk2.help",
+					"group": "navigation@1"
+				},
+				{
+					"when": "editorLangId == ahk2 && !isWeb && ahk2:isRunning",
+					"command": "ahk2.stop",
+					"group": "navigation@0"
+				},
+				{
+					"when": "editorLangId == ahk2",
+					"command": "ahk2.generate.comment",
+					"group": "navigation@2"
+				},
+				{
+					"when": "editorLangId == ahk2",
+					"command": "ahk2.updateversioninfo",
+					"group": "navigation@2"
+				}
+			],
+			"editor/title": [
+				{
+					"command": "ahk2.run",
+					"group": "navigation@0",
+					"when": "resourceLangId == ahk2 && shellExecutionSupported"
+				},
+				{
+					"command": "ahk2.stop",
+					"group": "navigation@0",
+					"when": "resourceLangId == ahk2 && ahk2:isRunning && shellExecutionSupported"
+				},
+				{
+					"command": "ahk2.debug",
+					"group": "navigation@1",
+					"when": "resourceLangId == ahk2 && shellExecutionSupported"
+				}
+			]
+		},
+		"keybindings": [
+			{
+				"command": "ahk2.run",
+				"key": "ctrl+f5",
+				"when": "editorLangId == ahk2 && !isWeb && !editorHasSelection"
+			},
+			{
+				"command": "ahk2.selection.run",
+				"key": "ctrl+f5",
+				"when": "editorLangId == ahk2 && !isWeb && editorHasSelection"
+			},
+			{
+				"command": "ahk2.compile",
+				"key": "ctrl+shift+f5",
+				"when": "editorLangId == ahk2 && !isWeb"
+			},
+			{
+				"command": "ahk2.debug",
+				"key": "f5",
+				"when": "editorLangId == ahk2 && !isWeb && !inDebugMode"
+			},
+			{
+				"command": "ahk2.debug.params",
+				"key": "shift+f5",
+				"when": "editorLangId == ahk2 && !isWeb"
+			},
+			{
+				"command": "ahk2.help",
+				"key": "ctrl+f1",
+				"when": "editorLangId == ahk2 && !isWeb"
+			},
+			{
+				"command": "ahk2.stop",
+				"key": "ctrl+f6",
+				"when": "editorLangId == ahk2 && !isWeb && ahk2:isRunning"
+			}
+		],
+		"semanticTokenScopes": [
+			{
+				"language": "ahk2",
+				"scopes": {
+					"operator": [
+						"keyword.operator.wordlike.ahk2"
+					]
+				}
+			}
+		]
+	},
+	"scripts": {
+		"vscode:prepublish": "webpack --mode production --devtool hidden-source-map",
+		"compile": "webpack",
+		"compile-cli": "webpack --config webpack.config.cli.js --mode production --devtool hidden-source-map",
+		"eslint": "eslint --fix",
+		"watch": "tsc -b -w",
+		"watch-web": "webpack --watch",
+		"patch": "npm version patch",
+		"publish": "vsce publish",
+		"package": "vsce package",
+		"chrome": "vscode-test-web --browserType=chromium --extensionDevelopmentPath=. ./test-data"
+	},
+	"devDependencies": {
+		"@eslint/js": "^9.4.0",
+		"@types/vscode": "^1.82.0",
+		"@vscode/vsce": "^2.27.0",
+		"eslint": "^9.4.0",
+		"globals": "^15.4.0",
+		"path-browserify": "^1.0.1",
+		"ts-loader": "^9.4.0",
+		"typescript": "^5.3.2",
+		"typescript-eslint": "^7.12.0",
+		"webpack": "^5.74.0",
+		"webpack-cli": "^4.10.0"
+	},
+	"dependencies": {
+		"vscode-languageclient": "^9.0.1",
+		"vscode-languageserver": "^9.0.1",
+		"vscode-languageserver-textdocument": "^1.0.11",
+		"vscode-uri": "^3.0.8"
+	}
 }

--- a/server/src/Lexer.ts
+++ b/server/src/Lexer.ts
@@ -553,6 +553,7 @@ export class Lexer {
 				preindent_string = input.substring(input.lastIndexOf('\n', parser_pos) + 1, parser_pos).match(/^[ \t]*/)![0];
 			}
 
+			// eslint-disable-next-line no-constant-condition
 			while (true) {
 				token_type = (ck = get_next_token()).type;
 				token_text_low = (token_text = ck.content).toLowerCase();
@@ -950,6 +951,7 @@ export class Lexer {
 										r += lk.content, tp = lk.type;
 									if (lk?.content === '<' && !lk.topofline) {
 										const generic_types: (string | AhkSymbol)[][] = [];
+										// eslint-disable-next-line no-constant-condition
 										while (true) {
 											generic_types.push(parse());
 											if (!lk || lk.content as string === '>') {
@@ -2203,6 +2205,7 @@ export class Lexer {
 					const tps: string[] = [];
 					next = true;
 					if (tk.content.toLowerCase() !== 'as') {
+						// eslint-disable-next-line no-constant-condition
 						while (true) {
 							let tp = '';
 							if (tk.type !== 'TK_WORD')
@@ -2211,6 +2214,7 @@ export class Lexer {
 							lk = tk, tk = get_token_ignore_comment();
 							if (tk.type === 'TK_DOT') {
 								nexttoken();
+								// eslint-disable-next-line no-constant-condition
 								while (true) {
 									if (tk.type as string === 'TK_WORD') {
 										addprop(tk), tp += '.' + tk.content;
@@ -2430,6 +2434,7 @@ export class Lexer {
 					else if (!tk.topofline || is_line_continue(lk, tk))
 						++info.count, nk = tk;
 				}
+				// eslint-disable-next-line no-constant-condition
 				while (true) {
 					res.push(...parse_expression(undefined, 0, end));
 					e ??= tk.offset;
@@ -2635,6 +2640,7 @@ export class Lexer {
 											_this.addDiagnostic(diagnostic.unexpected(tk.content), tk.offset, tk.length), next = false;
 										else err = diagnostic.propdeclaraerr();
 										if (!err) {
+											// eslint-disable-next-line no-constant-condition
 											while (true) {
 												if (tk.content === '.' && tk.type !== 'TK_OPERATOR') {
 													if (tk.type !== 'TK_DOT')
@@ -5088,6 +5094,7 @@ export class Lexer {
 				const comment_type = bg && '\n'.includes(input.charAt(last_LF)) ? 'TK_COMMENT' : (bg = 0, 'TK_INLINE_COMMENT');
 				let comment = '', t, rg: Range, ignore = undefined;
 				let next_LF = offset - 1, line: string, ln = 0, create_fr = true;
+				// eslint-disable-next-line no-constant-condition
 				while (true) {
 					parser_pos = next_LF, next_LF = input.indexOf('\n', parser_pos + 1);
 					line = input.substring(parser_pos + 1, next_LF = next_LF < 0 ? input_length : next_LF).trim();
@@ -6525,6 +6532,7 @@ export function get_class_member(lex: Lexer, node: AhkSymbol, name: string, isme
 	let prop, method, sym, t, i = 0, cls = node as ClassNode;
 	const _bases = bases ??= [];
 	name = name.toUpperCase();
+	// eslint-disable-next-line no-constant-condition
 	while (true) {
 		if (i === _bases.length) {
 			if (_bases.includes(cls))

--- a/server/src/PEFile.ts
+++ b/server/src/PEFile.ts
@@ -244,6 +244,7 @@ export class PEFile {
 			const stringFileInfo = getString(offset);
 			if (stringFileInfo.Key === 'StringFileInfo' && [0, 1].includes(stringFileInfo.Type) && stringFileInfo.ValueLength === 0) {
 				let stringTableOffset = alignDword(2 + nullindex, startOffset);
+				// eslint-disable-next-line no-constant-condition
 				while (true) {
 					const stringTable = getString(stringTableOffset);
 					const entries: any = {};
@@ -289,6 +290,7 @@ export function getFileVersion(path: string) {
 export async function searchAndOpenPEFile(path: string, isBit64?: boolean): Promise<PEFile | undefined> {
 	let pe: PEFile, file = '', dirs: string[] | undefined;
 	const exts: string[] = [''];
+	// eslint-disable-next-line no-constant-condition
 	while (true) {
 		try {
 			if (!existsSync(path))

--- a/server/src/ahkProvider.ts
+++ b/server/src/ahkProvider.ts
@@ -11,6 +11,7 @@ async function get_ahkProvider_port(): Promise<number> {
 		if (!executePath)
 			return resolve(0);
 		let server, port = 1200;
+		// eslint-disable-next-line no-constant-condition
 		while (true) {
 			try {
 				server = await createClientSocketTransport(port);


### PR DESCRIPTION
Ran `npm i -d eslint@^8.56.0` to resolve the ERESOLVE error. eslint@9.4.0 conflicts with eslint@^8.56.0 from typescript-eslint@7.12.0. The newest version of typescript-eslint has the same issue, so downgrading is the best option.

ESLint was not finding files (added `--debug` to confirm), you need to include a path, so I included `.` (the whole repo). This found some `while (true)` issues that I'm ignoring for now, you're welcome to remove this rule if you don't want it.