### PR TITLE
Use new config.ts for some config work

### DIFF
--- a/client/src/browserClientMain.ts
+++ b/client/src/browserClientMain.ts
@@ -1,5 +1,6 @@
 import { commands, ExtensionContext, languages, Range, RelativePattern, SnippetString, Uri, window, workspace, WorkspaceEdit } from 'vscode';
 import { LanguageClient } from 'vscode-languageclient/browser';
+import { configPrefix } from '../../util/src/config';
 
 let client: LanguageClient;
 
@@ -55,7 +56,7 @@ export function activate(context: ExtensionContext) {
 		initializationOptions: {
 			extensionUri: !process.env.DEBUG ? context.extensionUri.toString() : unpkg_url(context),
 			commands: Object.keys(request_handlers),
-			...JSON.parse(JSON.stringify(workspace.getConfiguration('AutoHotkey2')))
+			...JSON.parse(JSON.stringify(workspace.getConfiguration(configPrefix)))
 		}
 	}, new Worker(serverMain.toString()));
 

--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -28,10 +28,11 @@ import {
 import { resolve } from 'path';
 import { ChildProcess, exec, execSync, spawn } from 'child_process';
 import { readdirSync, readFileSync, lstatSync, readlinkSync, unlinkSync, writeFileSync } from 'fs';
+import { configPrefix } from '../../util/src/config';
 
 let client: LanguageClient, outputchannel: OutputChannel, ahkStatusBarItem: StatusBarItem;
 const ahkprocesses = new Map<number, ChildProcess & { path?: string }>();
-const ahkconfig = workspace.getConfiguration('AutoHotkey2');
+const ahkconfig = workspace.getConfiguration(configPrefix);
 let ahkpath_cur: string = ahkconfig.InterpreterPath, server_is_ready = false;
 const textdecoders = [new TextDecoder('utf8', { fatal: true }), new TextDecoder('utf-16le', { fatal: true })];
 const isWindows = process.platform === 'win32';
@@ -398,7 +399,7 @@ async function stopRunningScript() {
 }
 
 async function compileScript(textEditor: TextEditor) {
-	let cmd = '', cmdop = workspace.getConfiguration('AutoHotkey2').CompilerCMD as string;
+	let cmd = '', cmdop = workspace.getConfiguration(configPrefix).CompilerCMD as string;
 	const ws = workspace.getWorkspaceFolder(textEditor.document.uri)?.uri.fsPath ?? '';
 	const compilePath = findfile(['Compiler\\Ahk2Exe.exe', '..\\Compiler\\Ahk2Exe.exe'], ws);
 	const executePath = resolvePath(ahkpath_cur, ws);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "vscode-autohotkey2-lsp",
-	"version": "2.5.2",
+	"version": "2.5.3",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "vscode-autohotkey2-lsp",
-			"version": "2.5.2",
+			"version": "2.5.3",
 			"license": "LGPLv3.0",
 			"dependencies": {
 				"path-browserify": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -640,7 +640,8 @@
 		"publish": "vsce publish",
 		"test": "vscode-test",
 		"test-grammar": "vscode-tmgrammar-snap tmgrammar-test/*.ahk",
-		"vscode:prepublish": "node esbuild.mjs && npm run test && npm run test-grammar",
+		"validate": "node esbuild.mjs && npm run test && npm run test-grammar",
+		"vscode:prepublish": "npm run validate",
 		"watch": "node esbuild.mjs --dev",
 		"watch-web": "node esbuild.mjs --web"
 	},

--- a/server/src/Lexer.ts
+++ b/server/src/Lexer.ts
@@ -25,6 +25,7 @@ import {
 	hoverCache, isahk2_h, lexers, libdirs, libfuncs, locale, openAndParse, openFile,
 	restorePath, rootdir, setTextDocumentLanguage, symbolProvider, utils, workspaceFolders
 } from './common';
+import { ActionType, FormatOptions } from '../../util/src/config';
 
 export interface ParamInfo {
 	offset: number
@@ -196,28 +197,6 @@ export interface Context {
 	symbol?: AhkSymbol;
 };
 
-export interface FormatOptions {
-	array_style?: number
-	brace_style?: number
-	break_chained_methods?: boolean
-	ignore_comment?: boolean
-	indent_string?: string
-	indent_between_hotif_directive?: boolean
-	keyword_start_with_uppercase?: boolean
-	max_preserve_newlines?: number
-	object_style?: number
-	preserve_newlines?: boolean
-	space_before_conditional?: boolean
-	space_after_double_colon?: boolean
-	space_in_empty_paren?: boolean
-	space_in_other?: boolean
-	space_in_paren?: boolean
-	switch_case_alignment?: boolean
-	symbol_with_same_case?: boolean
-	white_space_before_inline_comment?: string
-	wrap_line_length?: number
-}
-
 interface ParamList extends Array<Variable> {
 	format?: (params: Variable[]) => void
 	hasref?: boolean
@@ -340,8 +319,6 @@ class ParseStopError {
 		this.token = token;
 	}
 }
-
-export type ActionType = 'Continue' | 'Warn' | 'SkipLine' | 'SwitchToV1' | 'Stop';
 
 export class Lexer {
 	public actionwhenv1?: ActionType = 'Continue';

--- a/server/src/browserServerMain.ts
+++ b/server/src/browserServerMain.ts
@@ -4,13 +4,14 @@ import {
 	InitializeResult, TextDocuments, TextDocumentSyncKind
 } from 'vscode-languageserver/browser';
 import {
-	AHKLSSettings, chinese_punctuations, colorPresentation, colorProvider, commands, completionProvider,
+	chinese_punctuations, colorPresentation, colorProvider, commands, completionProvider,
 	defintionProvider, documentFormatting, enumNames, executeCommandProvider, exportSymbols, getVersionInfo,
 	hoverProvider, initahk2cache, Lexer, lexers, loadahk2, loadlocalize, prepareRename, rangeFormatting,
 	referenceProvider, renameProvider, SemanticTokenModifiers, semanticTokensOnFull, semanticTokensOnRange,
 	SemanticTokenTypes, set_ahk_h, set_Connection, set_dirname, set_locale, set_version, set_WorkspaceFolders,
 	signatureProvider, symbolProvider, typeFormatting, update_settings, workspaceSymbolProvider
 } from './common';
+import { AHKLSSettings, configPrefix } from '../../util/src/config';
 
 const languageServer = 'ahk2-language-server';
 const messageReader = new BrowserMessageReader(self);
@@ -106,7 +107,7 @@ connection.onInitialized(() => {
 connection.onDidChangeConfiguration(async change => {
 	let newset: AHKLSSettings | undefined = change?.settings;
 	if (hasConfigurationCapability && !newset)
-		newset = await connection.workspace.getConfiguration('AutoHotkey2');
+		newset = await connection.workspace.getConfiguration(configPrefix);
 	if (!newset) {
 		connection.window.showWarningMessage('Failed to obtain the configuration');
 		return;

--- a/server/src/common.ts
+++ b/server/src/common.ts
@@ -4,9 +4,10 @@ import { readdirSync, readFileSync, existsSync, statSync, promises as fs } from 
 import { Connection, MessageConnection } from 'vscode-languageserver';
 import { TextDocument } from 'vscode-languageserver-textdocument';
 import { CompletionItem, CompletionItemKind, Hover, InsertTextFormat, Range, SymbolKind } from 'vscode-languageserver-types';
-import { AhkSymbol, ActionType, FormatOptions, Lexer, check_formatopts, update_comment_tags } from './Lexer';
+import { AhkSymbol, Lexer, check_formatopts, update_comment_tags } from './Lexer';
 import { diagnostic } from './localize';
 import { jsDocTagNames } from './constants';
+import { AHKLSSettings, LibIncludeType } from '../../util/src/config';
 export * from './codeActionProvider';
 export * from './colorProvider';
 export * from './commandProvider';
@@ -22,46 +23,6 @@ export * from './renameProvider';
 export * from './semanticTokensProvider';
 export * from './signatureProvider';
 export * from './symbolProvider';
-
-enum LibIncludeType {
-	'Disabled',
-	'Local',
-	'User and Standard',
-	'All'
-}
-
-export interface AHKLSSettings {
-	locale?: string
-	commands?: string[]
-	extensionUri?: string
-	ActionWhenV1IsDetected: ActionType
-	AutoLibInclude: LibIncludeType
-	CommentTags?: string
-	CompleteFunctionParens: boolean
-	CompletionCommitCharacters?: {
-		Class: string
-		Function: string
-	}
-	Diagnostics: {
-		ClassNonDynamicMemberCheck: boolean
-		ParamsCheck: boolean
-	}
-	Files: {
-		Exclude: string[]
-		MaxDepth: number
-	}
-	FormatOptions: FormatOptions
-	InterpreterPath: string
-	GlobalStorage?: string
-	Syntaxes?: string
-	SymbolFoldingFromOpenBrace: boolean
-	Warn: {
-		VarUnset: boolean
-		LocalSameAsGlobal: boolean
-		CallWithoutParentheses: boolean | /* Parentheses */ 1
-	}
-	WorkingDirs: string[]
-}
 
 export const winapis: string[] = [];
 export const lexers: Record<string, Lexer> = {};

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -7,7 +7,7 @@ import {
 import { URI } from 'vscode-uri';
 import { get_ahkProvider } from './ahkProvider';
 import {
-	a_vars, AHKLSSettings, ahkpath_cur, builtin_variable, builtin_variable_h, chinese_punctuations, clearLibfuns, codeActionProvider,
+	a_vars, ahkpath_cur, builtin_variable, builtin_variable_h, chinese_punctuations, clearLibfuns, codeActionProvider,
 	colorPresentation, colorProvider, commands, completionProvider, defintionProvider,
 	documentFormatting, enum_ahkfiles, executeCommandProvider, exportSymbols, extsettings, getVersionInfo, hoverProvider,
 	initahk2cache, isahk2_h, Lexer, lexers, libdirs, libfuncs, loadahk2, loadlocalize, openFile,
@@ -18,6 +18,7 @@ import {
 } from './common';
 import { PEFile, RESOURCE_TYPE, searchAndOpenPEFile } from './PEFile';
 import { resolvePath, runscript } from './scriptrunner';
+import { AHKLSSettings } from '../../util/src/config';
 
 const languageServer = 'ahk2-language-server';
 const documents = new TextDocuments(TextDocument);

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -18,7 +18,7 @@ import {
 } from './common';
 import { PEFile, RESOURCE_TYPE, searchAndOpenPEFile } from './PEFile';
 import { resolvePath, runscript } from './scriptrunner';
-import { AHKLSSettings } from '../../util/src/config';
+import { AHKLSSettings, configPrefix } from '../../util/src/config';
 
 const languageServer = 'ahk2-language-server';
 const documents = new TextDocuments(TextDocument);
@@ -124,7 +124,7 @@ connection.onInitialized(() => {
 connection.onDidChangeConfiguration(async change => {
 	let newset: AHKLSSettings | undefined = change?.settings;
 	if (hasConfigurationCapability && !newset)
-		newset = await connection.workspace.getConfiguration('AutoHotkey2');
+		newset = await connection.workspace.getConfiguration(configPrefix);
 	if (!newset) {
 		connection.window.showWarningMessage('Failed to obtain the configuration');
 		return;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,5 +7,5 @@
 		"noEmit": true,
 		"strict": true
 	},
-	"include": ["client/src", "server/src"]
+	"include": ["client/src", "server/src", "util/src"]
 }

--- a/util/src/config.ts
+++ b/util/src/config.ts
@@ -3,14 +3,17 @@ export enum CfgKey {
 	ActionWhenV1Detected = 'ActionWhenV1IsDetected',
 	CallWithoutParentheses = 'Warn.CallWithoutParentheses',
 	ClassNonDynamicMemberCheck = 'Diagnostics.ClassNonDynamicMemberCheck',
+	Commands = 'commands',
 	CommentTagRegex = 'CommentTags',
 	CompleteFunctionCalls = 'CompleteFunctionParens',
 	CompletionCommitCharacters = 'CompletionCommitCharacters',
 	Exclude = 'Files.Exclude',
+	ExtensionUri = 'extensionUri',
 	Formatter = 'FormatOptions',
 	InterpreterPath = 'InterpreterPath',
 	LibrarySuggestions = 'AutoLibInclude',
 	LocalSameAsGlobal = 'Warn.LocalSameAsGlobal',
+	Locale = 'locale',
 	MaxScanDepth = 'Files.ScanMaxDepth',
 	ParamsCheck = 'Diagnostics.ParamsCheck',
 	SymbolFoldingFromOpenBrace = 'SymbolFoldingFromOpenBrace',
@@ -50,6 +53,7 @@ export interface FormatOptions {
 	wrap_line_length?: number
 }
 
+/** Matches the contributed extension configuration */
 export interface AHKLSSettings {
 	locale?: string
 	commands?: string[]
@@ -82,3 +86,6 @@ export interface AHKLSSettings {
 	}
 	WorkingDirs: string[]
 }
+
+/** The start of each config value in package.json */
+export const configPrefix = 'AutoHotkey2';

--- a/util/src/config.ts
+++ b/util/src/config.ts
@@ -1,0 +1,84 @@
+//* Utility functions to access the config variable from either client or server
+export enum CfgKey {	
+	ActionWhenV1Detected = 'ActionWhenV1IsDetected',
+	CallWithoutParentheses = 'Warn.CallWithoutParentheses',
+	ClassNonDynamicMemberCheck = 'Diagnostics.ClassNonDynamicMemberCheck',
+	CommentTagRegex = 'CommentTags',
+	CompleteFunctionCalls = 'CompleteFunctionParens',
+	CompletionCommitCharacters = 'CompletionCommitCharacters',
+	Exclude = 'Files.Exclude',
+	Formatter = 'FormatOptions',
+	InterpreterPath = 'InterpreterPath',
+	LibrarySuggestions = 'AutoLibInclude',
+	LocalSameAsGlobal = 'Warn.LocalSameAsGlobal',
+	MaxScanDepth = 'Files.ScanMaxDepth',
+	ParamsCheck = 'Diagnostics.ParamsCheck',
+	SymbolFoldingFromOpenBrace = 'SymbolFoldingFromOpenBrace',
+	Syntaxes = 'Syntaxes',
+	VarUnset = 'Warn.varUnset',
+	WorkingDirectories = 'WorkingDirs',
+}
+
+export type ActionType = 'Continue' | 'Warn' | 'SkipLine' | 'SwitchToV1' | 'Stop';
+
+export enum LibIncludeType {
+	'Disabled',
+	'Local',
+	'User and Standard',
+	'All'
+}
+
+export interface FormatOptions {
+	array_style?: number
+	brace_style?: number
+	break_chained_methods?: boolean
+	ignore_comment?: boolean
+	indent_string?: string
+	indent_between_hotif_directive?: boolean
+	keyword_start_with_uppercase?: boolean
+	max_preserve_newlines?: number
+	object_style?: number
+	preserve_newlines?: boolean
+	space_before_conditional?: boolean
+	space_after_double_colon?: boolean
+	space_in_empty_paren?: boolean
+	space_in_other?: boolean
+	space_in_paren?: boolean
+	switch_case_alignment?: boolean
+	symbol_with_same_case?: boolean
+	white_space_before_inline_comment?: string
+	wrap_line_length?: number
+}
+
+export interface AHKLSSettings {
+	locale?: string
+	commands?: string[]
+	extensionUri?: string
+	ActionWhenV1IsDetected: ActionType
+	AutoLibInclude: LibIncludeType
+	CommentTags?: string
+	CompleteFunctionParens: boolean
+	CompletionCommitCharacters?: {
+		Class: string
+		Function: string
+	}
+	Diagnostics: {
+		ClassNonDynamicMemberCheck: boolean
+		ParamsCheck: boolean
+	}
+	Files: {
+		Exclude: string[]
+		MaxDepth: number
+	}
+	FormatOptions: FormatOptions
+	InterpreterPath: string
+	GlobalStorage?: string
+	Syntaxes?: string
+	SymbolFoldingFromOpenBrace: boolean
+	Warn: {
+		VarUnset: boolean
+		LocalSameAsGlobal: boolean
+		CallWithoutParentheses: boolean | /* Parentheses */ 1
+	}
+	WorkingDirs: string[]
+}


### PR DESCRIPTION
Organizing this will simplify imports and allow us to better fetch configs in the future

Ref https://github.com/mark-wiemer-org/ahk2-lsp/pull/42