### PR TITLE
Add config utilities and unit tests

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,5 +3,6 @@
 	"typescript.tsc.autoDetect": "off",
 	"typescript.preferences.quoteStyle": "single",
 	"git.ignoreLimitWarning": true,
-	"AutoHotkey2.InterpreterPath": "c:\\Program Files\\AutoHotkey\\v2\\AutoHotkey64.exe"
+	"AutoHotkey2.InterpreterPath": "c:\\Program Files\\AutoHotkey\\v2\\AutoHotkey64.exe",
+	"typescript.tsdk": "node_modules\\typescript\\lib"
 }

--- a/client/src/browserClientMain.ts
+++ b/client/src/browserClientMain.ts
@@ -1,5 +1,6 @@
 import { commands, ExtensionContext, languages, Range, RelativePattern, SnippetString, Uri, window, workspace, WorkspaceEdit } from 'vscode';
 import { LanguageClient } from 'vscode-languageclient/browser';
+import { configPrefix } from '../../util/src/config';
 
 let client: LanguageClient;
 
@@ -55,7 +56,7 @@ export function activate(context: ExtensionContext) {
 		initializationOptions: {
 			extensionUri: !process.env.DEBUG ? context.extensionUri.toString() : unpkg_url(context),
 			commands: Object.keys(request_handlers),
-			...JSON.parse(JSON.stringify(workspace.getConfiguration('AutoHotkey2')))
+			...JSON.parse(JSON.stringify(workspace.getConfiguration(configPrefix)))
 		}
 	}, new Worker(serverMain.toString()));
 

--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -28,10 +28,11 @@ import {
 import { resolve } from 'path';
 import { ChildProcess, exec, execSync, spawn } from 'child_process';
 import { readdirSync, readFileSync, lstatSync, readlinkSync, unlinkSync, writeFileSync } from 'fs';
+import { configPrefix } from '../../util/src/config';
 
 let client: LanguageClient, outputchannel: OutputChannel, ahkStatusBarItem: StatusBarItem;
 const ahkprocesses = new Map<number, ChildProcess & { path?: string }>();
-const ahkconfig = workspace.getConfiguration('AutoHotkey2');
+const ahkconfig = workspace.getConfiguration(configPrefix);
 let ahkpath_cur: string = ahkconfig.InterpreterPath, server_is_ready = false;
 const textdecoders = [new TextDecoder('utf8', { fatal: true }), new TextDecoder('utf-16le', { fatal: true })];
 const isWindows = process.platform === 'win32';
@@ -398,7 +399,7 @@ async function stopRunningScript() {
 }
 
 async function compileScript(textEditor: TextEditor) {
-	let cmd = '', cmdop = workspace.getConfiguration('AutoHotkey2').CompilerCMD as string;
+	let cmd = '', cmdop = workspace.getConfiguration(configPrefix).CompilerCMD as string;
 	const ws = workspace.getWorkspaceFolder(textEditor.document.uri)?.uri.fsPath ?? '';
 	const compilePath = findfile(['Compiler\\Ahk2Exe.exe', '..\\Compiler\\Ahk2Exe.exe'], ws);
 	const executePath = resolvePath(ahkpath_cur, ws);

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
 				"vscode-uri": "^3.0.8"
 			},
 			"devDependencies": {
+				"@types/mocha": "^10.0.8",
 				"@types/node": "^20.14.0",
 				"@types/vscode": "1.93.0",
 				"@vscode/test-cli": "^0.0.10",
@@ -23,6 +24,8 @@
 				"@vscode/vsce": "^2.32.0",
 				"esbuild": "^0.24.0",
 				"eslint": "^9.11.0",
+				"mocha": "^10.7.3",
+				"rimraf": "^6.0.1",
 				"typescript": "5.5.4",
 				"typescript-eslint": "^8.7.0",
 				"vscode-tmgrammar-test": "^0.1.3"
@@ -600,7 +603,8 @@
 			"version": "10.0.8",
 			"resolved": "https://registry.npmmirror.com/@types/mocha/-/mocha-10.0.8.tgz",
 			"integrity": "sha512-HfMcUmy9hTMJh66VNcmeC9iVErIZJli2bszuXc6julh5YGuRb/W5OnkHjwLNYdFlMis0sY3If5SEAp+PktdJjw==",
-			"dev": true
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/@types/node": {
 			"version": "20.16.10",
@@ -3394,6 +3398,7 @@
 			"resolved": "https://registry.npmmirror.com/mocha/-/mocha-10.7.3.tgz",
 			"integrity": "sha512-uQWxAu44wwiACGqjbPYmjo7Lg8sFrS3dQe7PP2FQI+woptP4vZXSMcfMyFL/e1yFEeEpV4RtyTpZROOKmxis+A==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"ansi-colors": "^4.1.3",
 				"browser-stdout": "^1.3.1",
@@ -4255,6 +4260,109 @@
 			"engines": {
 				"iojs": ">=1.0.0",
 				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/rimraf": {
+			"version": "6.0.1",
+			"resolved": "https://registry.npmmirror.com/rimraf/-/rimraf-6.0.1.tgz",
+			"integrity": "sha512-9dkvaxAsk/xNXSJzMgFqqMCuFgt2+KsOFek3TMLfo8NCPfWpBmqwyNn5Y+NX56QUYfCtsyhF3ayiboEoUmJk/A==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"glob": "^11.0.0",
+				"package-json-from-dist": "^1.0.0"
+			},
+			"bin": {
+				"rimraf": "dist/esm/bin.mjs"
+			},
+			"engines": {
+				"node": "20 || >=22"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/rimraf/node_modules/glob": {
+			"version": "11.0.0",
+			"resolved": "https://registry.npmmirror.com/glob/-/glob-11.0.0.tgz",
+			"integrity": "sha512-9UiX/Bl6J2yaBbxKoEBRm4Cipxgok8kQYcOPEhScPwebu2I0HoQOuYdIO6S3hLuWoZgpDpwQZMzTFxgpkyT76g==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"foreground-child": "^3.1.0",
+				"jackspeak": "^4.0.1",
+				"minimatch": "^10.0.0",
+				"minipass": "^7.1.2",
+				"package-json-from-dist": "^1.0.0",
+				"path-scurry": "^2.0.0"
+			},
+			"bin": {
+				"glob": "dist/esm/bin.mjs"
+			},
+			"engines": {
+				"node": "20 || >=22"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/rimraf/node_modules/jackspeak": {
+			"version": "4.0.2",
+			"resolved": "https://registry.npmmirror.com/jackspeak/-/jackspeak-4.0.2.tgz",
+			"integrity": "sha512-bZsjR/iRjl1Nk1UkjGpAzLNfQtzuijhn2g+pbZb98HQ1Gk8vM9hfbxeMBP+M2/UUdwj0RqGG3mlvk2MsAqwvEw==",
+			"dev": true,
+			"license": "BlueOak-1.0.0",
+			"dependencies": {
+				"@isaacs/cliui": "^8.0.2"
+			},
+			"engines": {
+				"node": "20 || >=22"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/rimraf/node_modules/lru-cache": {
+			"version": "11.0.1",
+			"resolved": "https://registry.npmmirror.com/lru-cache/-/lru-cache-11.0.1.tgz",
+			"integrity": "sha512-CgeuL5uom6j/ZVrg7G/+1IXqRY8JXX4Hghfy5YE0EhoYQWvndP1kufu58cmZLNIDKnRhZrXfdS9urVWx98AipQ==",
+			"dev": true,
+			"license": "ISC",
+			"engines": {
+				"node": "20 || >=22"
+			}
+		},
+		"node_modules/rimraf/node_modules/minimatch": {
+			"version": "10.0.1",
+			"resolved": "https://registry.npmmirror.com/minimatch/-/minimatch-10.0.1.tgz",
+			"integrity": "sha512-ethXTt3SGGR+95gudmqJ1eNhRO7eGEGIgYA9vnPatK4/etz2MEVDno5GMCibdMTuBMyElzIlgxMna3K94XDIDQ==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"brace-expansion": "^2.0.1"
+			},
+			"engines": {
+				"node": "20 || >=22"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/rimraf/node_modules/path-scurry": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmmirror.com/path-scurry/-/path-scurry-2.0.0.tgz",
+			"integrity": "sha512-ypGJsmGtdXUOeM5u93TyeIEfEhM6s+ljAhrk5vAvSx8uyY/02OvrZnA0YNGUrPXfpJMgI1ODd3nwz8Npx4O4cg==",
+			"dev": true,
+			"license": "BlueOak-1.0.0",
+			"dependencies": {
+				"lru-cache": "^11.0.0",
+				"minipass": "^7.1.2"
+			},
+			"engines": {
+				"node": "20 || >=22"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
 			}
 		},
 		"node_modules/run-parallel": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "vscode-autohotkey2-lsp",
-	"version": "2.5.2",
+	"version": "2.5.3",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "vscode-autohotkey2-lsp",
-			"version": "2.5.2",
+			"version": "2.5.3",
 			"license": "LGPLv3.0",
 			"dependencies": {
 				"path-browserify": "^1.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -4850,6 +4850,7 @@
 			"resolved": "https://registry.npmmirror.com/typescript/-/typescript-5.5.4.tgz",
 			"integrity": "sha512-Mtq29sKDAEYP7aljRgtPOpTvOfbwRWlS6dPRzwjdE+C0R4brX/GUyhHSecbHMFLNBLcJIPt9nl9yG5TZ1weH+Q==",
 			"dev": true,
+			"license": "Apache-2.0",
 			"bin": {
 				"tsc": "bin/tsc",
 				"tsserver": "bin/tsserver"

--- a/package.json
+++ b/package.json
@@ -640,7 +640,8 @@
 		"publish": "vsce publish",
 		"test": "vscode-test",
 		"test-grammar": "vscode-tmgrammar-snap tmgrammar-test/*.ahk",
-		"vscode:prepublish": "node esbuild.mjs && npm run test && npm run test-grammar",
+		"validate": "node esbuild.mjs && npm run test && npm run test-grammar",
+		"vscode:prepublish": "npm run validate",
 		"watch": "node esbuild.mjs --dev",
 		"watch-web": "node esbuild.mjs --web"
 	},

--- a/package.json
+++ b/package.json
@@ -634,18 +634,29 @@
 	},
 	"scripts": {
 		"check-types": "tsc",
-		"build-cli": "node esbuild.mjs --cli",
+		"build:cli": "npm run build -- --cli",
+		"build": "node esbuild.mjs",
+		"clean:out": "rimraf out",
+		"precompile-ts": "npm run clean:out",
+		"compile-ts": "tsc --noEmit false --outDir out",
 		"eslint": "eslint --fix",
 		"package": "vsce package",
 		"publish": "vsce publish",
-		"test": "vscode-test",
-		"test-grammar": "vscode-tmgrammar-snap tmgrammar-test/*.ahk",
-		"validate": "node esbuild.mjs && npm run test && npm run test-grammar",
-		"vscode:prepublish": "npm run validate",
-		"watch": "node esbuild.mjs --dev",
-		"watch-web": "node esbuild.mjs --web"
+		"test": "npm run test:grammar && npm run test:unit && npm run test:e2e",
+		"pretest:e2e": "npm run build",
+		"test:e2e": "vscode-test",
+		"test:grammar": "vscode-tmgrammar-snap tmgrammar-test/*.ahk",
+		"pretest:unit": "npm run compile-ts",
+		"test:unit": "mocha",
+		"vscode:prepublish": "npm run test",
+		"watch": "npm run build -- --dev",
+		"watch-web": "npm run build -- --web"
+	},
+	"mocha": {
+		"spec": "out/**/*.spec.js"
 	},
 	"devDependencies": {
+		"@types/mocha": "^10.0.8",
 		"@types/node": "^20.14.0",
 		"@types/vscode": "1.93.0",
 		"@vscode/test-cli": "^0.0.10",
@@ -653,6 +664,8 @@
 		"@vscode/vsce": "^2.32.0",
 		"esbuild": "^0.24.0",
 		"eslint": "^9.11.0",
+		"mocha": "^10.7.3",
+		"rimraf": "^6.0.1",
 		"typescript": "5.5.4",
 		"typescript-eslint": "^8.7.0",
 		"vscode-tmgrammar-test": "^0.1.3"

--- a/server/src/Lexer.ts
+++ b/server/src/Lexer.ts
@@ -25,7 +25,7 @@ import {
 	hoverCache, isahk2_h, lexers, libdirs, libfuncs, locale, openAndParse, openFile,
 	restorePath, rootdir, setTextDocumentLanguage, symbolProvider, utils, workspaceFolders
 } from './common';
-import { ActionType, ahklsConfig, FormatOptions } from '../../util/src/config';
+import { ActionType, ahklsConfig, CfgKey, FormatOptions, getCfg } from '../../util/src/config';
 
 export interface ParamInfo {
 	offset: number
@@ -1194,7 +1194,7 @@ export class Lexer {
 			if (requirev2)
 				return false;
 			_this.maybev1 ??= maybev1 = 1;
-			switch (_this.actionwhenv1 ??= ahklsConfig.ActionWhenV1IsDetected) {
+			switch (_this.actionwhenv1 ??= getCfg(CfgKey.ActionWhenV1Detected)) {
 				case 'SkipLine': {
 					if (!allow_skip)
 						return true;

--- a/server/src/Lexer.ts
+++ b/server/src/Lexer.ts
@@ -25,6 +25,7 @@ import {
 	hoverCache, isahk2_h, lexers, libdirs, libfuncs, locale, openAndParse, openFile,
 	restorePath, rootdir, setTextDocumentLanguage, symbolProvider, utils, workspaceFolders
 } from './common';
+import { ActionType, FormatOptions } from '../../util/src/config';
 
 export interface ParamInfo {
 	offset: number
@@ -196,28 +197,6 @@ export interface Context {
 	symbol?: AhkSymbol;
 };
 
-export interface FormatOptions {
-	array_style?: number
-	brace_style?: number
-	break_chained_methods?: boolean
-	ignore_comment?: boolean
-	indent_string?: string
-	indent_between_hotif_directive?: boolean
-	keyword_start_with_uppercase?: boolean
-	max_preserve_newlines?: number
-	object_style?: number
-	preserve_newlines?: boolean
-	space_before_conditional?: boolean
-	space_after_double_colon?: boolean
-	space_in_empty_paren?: boolean
-	space_in_other?: boolean
-	space_in_paren?: boolean
-	switch_case_alignment?: boolean
-	symbol_with_same_case?: boolean
-	white_space_before_inline_comment?: string
-	wrap_line_length?: number
-}
-
 interface ParamList extends Array<Variable> {
 	format?: (params: Variable[]) => void
 	hasref?: boolean
@@ -340,8 +319,6 @@ class ParseStopError {
 		this.token = token;
 	}
 }
-
-export type ActionType = 'Continue' | 'Warn' | 'SkipLine' | 'SwitchToV1' | 'Stop';
 
 export class Lexer {
 	public actionwhenv1?: ActionType = 'Continue';

--- a/server/src/Lexer.ts
+++ b/server/src/Lexer.ts
@@ -21,11 +21,11 @@ import { URI } from 'vscode-uri';
 import { builtin_ahkv1_commands, builtin_variable, builtin_variable_h } from './constants';
 import { action, completionitem, diagnostic, warn } from './localize';
 import {
-	a_vars, ahk_version, ahkuris, ahkvars, alpha_3, connection, ahklsConfig,
+	a_vars, ahk_version, ahkuris, ahkvars, alpha_3, connection,
 	hoverCache, isahk2_h, lexers, libdirs, libfuncs, locale, openAndParse, openFile,
 	restorePath, rootdir, setTextDocumentLanguage, symbolProvider, utils, workspaceFolders
 } from './common';
-import { ActionType, FormatOptions } from '../../util/src/config';
+import { ActionType, ahklsConfig, FormatOptions } from '../../util/src/config';
 
 export interface ParamInfo {
 	offset: number

--- a/server/src/Lexer.ts
+++ b/server/src/Lexer.ts
@@ -21,7 +21,7 @@ import { URI } from 'vscode-uri';
 import { builtin_ahkv1_commands, builtin_variable, builtin_variable_h } from './constants';
 import { action, completionitem, diagnostic, warn } from './localize';
 import {
-	a_vars, ahk_version, ahkuris, ahkvars, alpha_3, connection, extsettings,
+	a_vars, ahk_version, ahkuris, ahkvars, alpha_3, connection, ahklsConfig,
 	hoverCache, isahk2_h, lexers, libdirs, libfuncs, locale, openAndParse, openFile,
 	restorePath, rootdir, setTextDocumentLanguage, symbolProvider, utils, workspaceFolders
 } from './common';
@@ -1155,7 +1155,7 @@ export class Lexer {
 				begin_line = true, requirev2 = false, maybev1 = 0, lst = { ...EMPTY_TOKEN }, currsymbol = last_comment_fr = undefined;
 				parser_pos = 0, last_LF = -1, customblocks = { region: [], bracket: [] }, continuation_sections_mode = false, h = isahk2_h;
 				this.clear(), includetable = this.include, comments = {}, sharp_offsets = [];
-				callWithoutParentheses = extsettings.Warn?.CallWithoutParentheses;
+				callWithoutParentheses = ahklsConfig.Warn?.CallWithoutParentheses;
 				try {
 					const rs = utils.get_RCDATA('#2');
 					rs && (includetable[rs.uri] = rs.path);
@@ -1194,7 +1194,7 @@ export class Lexer {
 			if (requirev2)
 				return false;
 			_this.maybev1 ??= maybev1 = 1;
-			switch (_this.actionwhenv1 ??= extsettings.ActionWhenV1IsDetected) {
+			switch (_this.actionwhenv1 ??= ahklsConfig.ActionWhenV1IsDetected) {
 				case 'SkipLine': {
 					if (!allow_skip)
 						return true;
@@ -3671,7 +3671,7 @@ export class Lexer {
 					nexttoken(), parse_pair('(', ')');
 					const pc = tokens[tk.previous_pair_pos!]?.paraminfo?.count ?? 0;
 					if (pc !== 1)
-						extsettings.Diagnostics.ParamsCheck && _this.addDiagnostic(diagnostic.paramcounterr(1, pc), fc.offset, parser_pos - fc.offset);
+						ahklsConfig.Diagnostics.ParamsCheck && _this.addDiagnostic(diagnostic.paramcounterr(1, pc), fc.offset, parser_pos - fc.offset);
 					else if (result.length > l && lk.type === 'TK_WORD') {
 						const vr = result.at(-1) as Variable;
 						if (lk.content === vr.name && lk.offset === _this.document.offsetAt(vr.range.start))
@@ -6315,7 +6315,7 @@ export class Lexer {
 			return;
 		let workfolder: string;
 		if (!dir) {
-			for (workfolder of extsettings.WorkingDirs)
+			for (workfolder of ahklsConfig.WorkingDirs)
 				if (this.uri.startsWith(workfolder)) {
 					dir = restorePath(URI.parse(workfolder).fsPath.replace(/[\\/]$/, ''));
 					break;
@@ -6373,7 +6373,7 @@ export class Lexer {
 	}
 
 	private addSymbolFolding(symbol: AhkSymbol, first_brace: number) {
-		const l1 = extsettings.SymbolFoldingFromOpenBrace ? this.document.positionAt(first_brace).line : symbol.range.start.line;
+		const l1 = ahklsConfig.SymbolFoldingFromOpenBrace ? this.document.positionAt(first_brace).line : symbol.range.start.line;
 		const l2 = symbol.range.end.line - 1;
 		const ranges = this.foldingranges;
 		if (l1 < l2) {

--- a/server/src/browserServerMain.ts
+++ b/server/src/browserServerMain.ts
@@ -78,7 +78,7 @@ connection.onInitialize(params => {
 	const initialConfig: AHKLSConfig = params.initializationOptions;
 	set_ahk_h(true);
 	set_locale(params.locale);
-	set_dirname(getCfg(initialConfig, CfgKey.ExtensionUri));
+	set_dirname(getCfg(CfgKey.ExtensionUri, initialConfig));
 	loadlocalize();
 	updateConfig(initialConfig);
 	set_WorkspaceFolders(workspaceFolders);

--- a/server/src/browserServerMain.ts
+++ b/server/src/browserServerMain.ts
@@ -11,7 +11,7 @@ import {
 	SemanticTokenTypes, set_ahk_h, set_Connection, set_dirname, set_locale, set_version, set_WorkspaceFolders,
 	signatureProvider, symbolProvider, typeFormatting, updateConfig, workspaceSymbolProvider
 } from './common';
-import { AHKLSConfig, configPrefix } from '../../util/src/config';
+import { AHKLSConfig, CfgKey, configPrefix, getCfg } from '../../util/src/config';
 
 const languageServer = 'ahk2-language-server';
 const messageReader = new BrowserMessageReader(self);
@@ -75,12 +75,12 @@ connection.onInitialize(params => {
 		result.capabilities.workspace = { workspaceFolders: { supported: true } };
 	}
 
-	const configs: AHKLSConfig = params.initializationOptions;
+	const initialConfig: AHKLSConfig = params.initializationOptions;
 	set_ahk_h(true);
 	set_locale(params.locale);
-	set_dirname(configs.extensionUri!);
+	set_dirname(getCfg(initialConfig, CfgKey.ExtensionUri));
 	loadlocalize();
-	updateConfig(configs);
+	updateConfig(initialConfig);
 	set_WorkspaceFolders(workspaceFolders);
 	set_version('3.0.0');
 	initahk2cache();

--- a/server/src/browserServerMain.ts
+++ b/server/src/browserServerMain.ts
@@ -4,13 +4,14 @@ import {
 	InitializeResult, TextDocuments, TextDocumentSyncKind
 } from 'vscode-languageserver/browser';
 import {
-	AHKLSSettings, chinese_punctuations, colorPresentation, colorProvider, commands, completionProvider,
+	chinese_punctuations, colorPresentation, colorProvider, commands, completionProvider,
 	defintionProvider, documentFormatting, enumNames, executeCommandProvider, exportSymbols, getVersionInfo,
 	hoverProvider, initahk2cache, Lexer, lexers, loadahk2, loadlocalize, prepareRename, rangeFormatting,
 	referenceProvider, renameProvider, SemanticTokenModifiers, semanticTokensOnFull, semanticTokensOnRange,
 	SemanticTokenTypes, set_ahk_h, set_Connection, set_dirname, set_locale, set_version, set_WorkspaceFolders,
 	signatureProvider, symbolProvider, typeFormatting, update_settings, workspaceSymbolProvider
 } from './common';
+import { AHKLSSettings, configPrefix } from '../../util/src/config';
 
 const languageServer = 'ahk2-language-server';
 const messageReader = new BrowserMessageReader(self);
@@ -106,7 +107,7 @@ connection.onInitialized(() => {
 connection.onDidChangeConfiguration(async change => {
 	let newset: AHKLSSettings | undefined = change?.settings;
 	if (hasConfigurationCapability && !newset)
-		newset = await connection.workspace.getConfiguration('AutoHotkey2');
+		newset = await connection.workspace.getConfiguration(configPrefix);
 	if (!newset) {
 		connection.window.showWarningMessage('Failed to obtain the configuration');
 		return;

--- a/server/src/browserServerMain.ts
+++ b/server/src/browserServerMain.ts
@@ -11,7 +11,7 @@ import {
 	SemanticTokenTypes, set_ahk_h, set_Connection, set_dirname, set_locale, set_version, set_WorkspaceFolders,
 	signatureProvider, symbolProvider, typeFormatting, update_settings, workspaceSymbolProvider
 } from './common';
-import { AHKLSSettings, configPrefix } from '../../util/src/config';
+import { AHKLSConfig, configPrefix } from '../../util/src/config';
 
 const languageServer = 'ahk2-language-server';
 const messageReader = new BrowserMessageReader(self);
@@ -75,7 +75,7 @@ connection.onInitialize(params => {
 		result.capabilities.workspace = { workspaceFolders: { supported: true } };
 	}
 
-	const configs: AHKLSSettings = params.initializationOptions;
+	const configs: AHKLSConfig = params.initializationOptions;
 	set_ahk_h(true);
 	set_locale(params.locale);
 	set_dirname(configs.extensionUri!);
@@ -105,7 +105,7 @@ connection.onInitialized(() => {
 });
 
 connection.onDidChangeConfiguration(async change => {
-	let newset: AHKLSSettings | undefined = change?.settings;
+	let newset: AHKLSConfig | undefined = change?.settings;
 	if (hasConfigurationCapability && !newset)
 		newset = await connection.workspace.getConfiguration(configPrefix);
 	if (!newset) {

--- a/server/src/browserServerMain.ts
+++ b/server/src/browserServerMain.ts
@@ -9,7 +9,7 @@ import {
 	hoverProvider, initahk2cache, Lexer, lexers, loadahk2, loadlocalize, prepareRename, rangeFormatting,
 	referenceProvider, renameProvider, SemanticTokenModifiers, semanticTokensOnFull, semanticTokensOnRange,
 	SemanticTokenTypes, set_ahk_h, set_Connection, set_dirname, set_locale, set_version, set_WorkspaceFolders,
-	signatureProvider, symbolProvider, typeFormatting, update_settings, workspaceSymbolProvider
+	signatureProvider, symbolProvider, typeFormatting, updateConfig, workspaceSymbolProvider
 } from './common';
 import { AHKLSConfig, configPrefix } from '../../util/src/config';
 
@@ -80,7 +80,7 @@ connection.onInitialize(params => {
 	set_locale(params.locale);
 	set_dirname(configs.extensionUri!);
 	loadlocalize();
-	update_settings(configs);
+	updateConfig(configs);
 	set_WorkspaceFolders(workspaceFolders);
 	set_version('3.0.0');
 	initahk2cache();
@@ -112,7 +112,7 @@ connection.onDidChangeConfiguration(async change => {
 		connection.window.showWarningMessage('Failed to obtain the configuration');
 		return;
 	}
-	update_settings(newset);
+	updateConfig(newset);
 	set_WorkspaceFolders(workspaceFolders);
 });
 

--- a/server/src/commandProvider.ts
+++ b/server/src/commandProvider.ts
@@ -5,10 +5,10 @@ import {
 	join_types, lexers, parse_include, restorePath, semanticTokensOnFull,
 	traverse_include, update_include_cache
 } from './common';
-import { CfgKey, getCfg, ahklsConfig } from '../../util/src/config';
+import { CfgKey, getCfg } from '../../util/src/config';
 
 function checkCommand(cmd: string) {
-	if (getCfg(ahklsConfig, CfgKey.Commands)?.includes(cmd))
+	if (getCfg(CfgKey.Commands)?.includes(cmd))
 		return true;
 	connection?.console.warn(`Command '${cmd}' is not implemented!`);
 	return false;

--- a/server/src/commandProvider.ts
+++ b/server/src/commandProvider.ts
@@ -1,13 +1,14 @@
 import { CancellationToken, ExecuteCommandParams, Position, Range, SymbolKind } from 'vscode-languageserver';
 import {
 	AhkSymbol, ClassNode, FuncNode, Lexer, Property, Token, Variable,
-	connection, extsettings, find_class, generate_type_annotation,
+	connection, ahklsConfig, find_class, generate_type_annotation,
 	join_types, lexers, parse_include, restorePath, semanticTokensOnFull,
 	traverse_include, update_include_cache
 } from './common';
+import { CfgKey, getCfg } from '../../util/src/config';
 
 function checkCommand(cmd: string) {
-	if (extsettings.commands?.includes(cmd))
+	if (getCfg(ahklsConfig, CfgKey.Commands)?.includes(cmd))
 		return true;
 	connection?.console.warn(`Command '${cmd}' is not implemented!`);
 	return false;

--- a/server/src/commandProvider.ts
+++ b/server/src/commandProvider.ts
@@ -1,11 +1,11 @@
 import { CancellationToken, ExecuteCommandParams, Position, Range, SymbolKind } from 'vscode-languageserver';
 import {
 	AhkSymbol, ClassNode, FuncNode, Lexer, Property, Token, Variable,
-	connection, ahklsConfig, find_class, generate_type_annotation,
+	connection, find_class, generate_type_annotation,
 	join_types, lexers, parse_include, restorePath, semanticTokensOnFull,
 	traverse_include, update_include_cache
 } from './common';
-import { CfgKey, getCfg } from '../../util/src/config';
+import { CfgKey, getCfg, ahklsConfig } from '../../util/src/config';
 
 function checkCommand(cmd: string) {
 	if (getCfg(ahklsConfig, CfgKey.Commands)?.includes(cmd))

--- a/server/src/common.ts
+++ b/server/src/common.ts
@@ -7,7 +7,7 @@ import { CompletionItem, CompletionItemKind, Hover, InsertTextFormat, Range, Sym
 import { AhkSymbol, Lexer, check_formatopts, update_comment_tags } from './Lexer';
 import { diagnostic } from './localize';
 import { jsDocTagNames } from './constants';
-import { AHKLSSettings, LibIncludeType } from '../../util/src/config';
+import { AHKLSConfig, LibIncludeType } from '../../util/src/config';
 export * from './codeActionProvider';
 export * from './colorProvider';
 export * from './commandProvider';
@@ -27,7 +27,7 @@ export * from './symbolProvider';
 export const winapis: string[] = [];
 export const lexers: Record<string, Lexer> = {};
 export const alpha_3 = encode_version('2.1-alpha.3');
-export const extsettings: AHKLSSettings = {
+export const extsettings: AHKLSConfig = {
 	ActionWhenV1IsDetected: 'Warn',
 	AutoLibInclude: 0,
 	CommentTags: '^;;\\s*(.*)',
@@ -388,7 +388,7 @@ export function enum_ahkfiles(dirpath: string) {
 	}
 }
 
-export function update_settings(configs: AHKLSSettings) {
+export function update_settings(configs: AHKLSConfig) {
 	if (typeof configs.AutoLibInclude === 'string')
 		configs.AutoLibInclude = LibIncludeType[configs.AutoLibInclude] as unknown as LibIncludeType;
 	else if (typeof configs.AutoLibInclude === 'boolean')

--- a/server/src/common.ts
+++ b/server/src/common.ts
@@ -7,7 +7,7 @@ import { CompletionItem, CompletionItemKind, Hover, InsertTextFormat, Range, Sym
 import { AhkSymbol, Lexer, check_formatopts, update_comment_tags } from './Lexer';
 import { diagnostic } from './localize';
 import { jsDocTagNames } from './constants';
-import { AHKLSConfig, LibIncludeType } from '../../util/src/config';
+import { ahklsConfig, AHKLSConfig, LibIncludeType } from '../../util/src/config';
 export * from './codeActionProvider';
 export * from './colorProvider';
 export * from './commandProvider';
@@ -27,33 +27,6 @@ export * from './symbolProvider';
 export const winapis: string[] = [];
 export const lexers: Record<string, Lexer> = {};
 export const alpha_3 = encode_version('2.1-alpha.3');
-export const ahklsConfig: AHKLSConfig = {
-	ActionWhenV1IsDetected: 'Warn',
-	AutoLibInclude: 0,
-	CommentTags: '^;;\\s*(.*)',
-	CompleteFunctionParens: false,
-	CompletionCommitCharacters: {
-		Class: '.(',
-		Function: '('
-	},
-	Diagnostics: {
-		ClassNonDynamicMemberCheck: true,
-		ParamsCheck: true
-	},
-	Files: {
-		Exclude: [],
-		MaxDepth: 2
-	},
-	FormatOptions: {},
-	InterpreterPath: 'C:\\Program Files\\AutoHotkey\\v2\\AutoHotkey.exe',
-	SymbolFoldingFromOpenBrace: false,
-	Warn: {
-		VarUnset: true,
-		LocalSameAsGlobal: false,
-		CallWithoutParentheses: false
-	},
-	WorkingDirs: []
-};
 export const utils = {
 	get_DllExport: (_paths: string[] | Set<string>, _onlyone = false) => Promise.resolve([] as string[]),
 	get_RCDATA: (_path?: string) => undefined as { uri: string, path: string, paths?: string[] } | undefined,

--- a/server/src/common.ts
+++ b/server/src/common.ts
@@ -4,9 +4,10 @@ import { readdirSync, readFileSync, existsSync, statSync, promises as fs } from 
 import { Connection, MessageConnection } from 'vscode-languageserver';
 import { TextDocument } from 'vscode-languageserver-textdocument';
 import { CompletionItem, CompletionItemKind, Hover, InsertTextFormat, Range, SymbolKind } from 'vscode-languageserver-types';
-import { AhkSymbol, ActionType, FormatOptions, Lexer, check_formatopts, update_comment_tags } from './Lexer';
+import { AhkSymbol, Lexer, check_formatopts, update_comment_tags } from './Lexer';
 import { diagnostic } from './localize';
 import { jsDocTagNames } from './constants';
+import { AHKLSSettings, LibIncludeType } from '../../util/src/config';
 export * from './codeActionProvider';
 export * from './colorProvider';
 export * from './commandProvider';
@@ -22,46 +23,6 @@ export * from './renameProvider';
 export * from './semanticTokensProvider';
 export * from './signatureProvider';
 export * from './symbolProvider';
-
-enum LibIncludeType {
-	'Disabled',
-	'Local',
-	'User and Standard',
-	'All'
-}
-
-export interface AHKLSSettings {
-	locale?: string
-	commands?: string[]
-	extensionUri?: string
-	ActionWhenV1IsDetected: ActionType
-	AutoLibInclude: LibIncludeType
-	CommentTags?: string
-	CompleteFunctionParens: boolean
-	CompletionCommitCharacters?: {
-		Class: string
-		Function: string
-	}
-	Diagnostics: {
-		ClassNonDynamicMemberCheck: boolean
-		ParamsCheck: boolean
-	}
-	Files: {
-		Exclude: string[]
-		MaxDepth: number
-	}
-	FormatOptions: FormatOptions
-	InterpreterPath: string
-	GlobalStorage?: string
-	Syntaxes?: string
-	SymbolFoldingFromOpenBrace: boolean
-	Warn: {
-		VarUnset: boolean
-		LocalSameAsGlobal: boolean
-		CallWithoutParentheses: boolean | /* Parentheses */ 1
-	}
-	WorkingDirs: string[]
-}
 
 export const winapis: string[] = [];
 export const lexers: Record<string, Lexer> = {};

--- a/server/src/common.ts
+++ b/server/src/common.ts
@@ -27,7 +27,7 @@ export * from './symbolProvider';
 export const winapis: string[] = [];
 export const lexers: Record<string, Lexer> = {};
 export const alpha_3 = encode_version('2.1-alpha.3');
-export const extsettings: AHKLSConfig = {
+export const ahklsConfig: AHKLSConfig = {
 	ActionWhenV1IsDetected: 'Warn',
 	AutoLibInclude: 0,
 	CommentTags: '^;;\\s*(.*)',
@@ -230,7 +230,7 @@ export function loadahk2(filename = 'ahk2', d = 3) {
 		if ((data = getwebfile(file + '.json')))
 			build_item_cache(JSON.parse(data.text));
 	} else {
-		const syntaxes = extsettings.Syntaxes && existsSync(extsettings.Syntaxes) ? extsettings.Syntaxes : '';
+		const syntaxes = ahklsConfig.Syntaxes && existsSync(ahklsConfig.Syntaxes) ? ahklsConfig.Syntaxes : '';
 		const file2 = syntaxes ? `${syntaxes}/<>/${filename}` : file;
 		let td: TextDocument | undefined;
 		if ((path = getfilepath('.d.ahk')) && (td = openFile(restorePath(path)))) {
@@ -367,7 +367,7 @@ export function loadahk2(filename = 'ahk2', d = 3) {
 
 let scanExclude: { file?: RegExp[], folder?: RegExp[] } = {};
 export function enum_ahkfiles(dirpath: string) {
-	const maxdepth = extsettings.Files.MaxDepth;
+	const maxdepth = ahklsConfig.Files.MaxDepth;
 	const { file: file_exclude, folder: folder_exclude } = scanExclude;
 	return enumfile(restorePath(dirpath), 0);
 	async function* enumfile(dirpath: string, depth: number): AsyncGenerator<string> {
@@ -426,7 +426,7 @@ export function update_settings(configs: AHKLSConfig) {
 	}
 	if (configs.Syntaxes)
 		configs.Syntaxes = resolve(configs.Syntaxes).toLowerCase();
-	Object.assign(extsettings, configs);
+	Object.assign(ahklsConfig, configs);
 }
 
 function encode_version(version: string) {
@@ -472,7 +472,7 @@ export function set_version(version: string) { ahk_version = encode_version(vers
 export function set_WorkspaceFolders(folders: Set<string>) {
 	const old = workspaceFolders;
 	workspaceFolders = [...folders];
-	extsettings.WorkingDirs.forEach(it => !folders.has(it) && workspaceFolders.push(it));
+	ahklsConfig.WorkingDirs.forEach(it => !folders.has(it) && workspaceFolders.push(it));
 	workspaceFolders.sort().reverse();
 	if (old.length === workspaceFolders.length &&
 		!old.some((v, i) => workspaceFolders[i] !== v))

--- a/server/src/common.ts
+++ b/server/src/common.ts
@@ -388,7 +388,11 @@ export function enum_ahkfiles(dirpath: string) {
 	}
 }
 
-export function update_settings(configs: AHKLSConfig) {
+/**
+ * Update the extension config in-memory.
+ * Does not update user settings.
+ */
+export function updateConfig(configs: AHKLSConfig) {
 	if (typeof configs.AutoLibInclude === 'string')
 		configs.AutoLibInclude = LibIncludeType[configs.AutoLibInclude] as unknown as LibIncludeType;
 	else if (typeof configs.AutoLibInclude === 'boolean')

--- a/server/src/completionProvider.ts
+++ b/server/src/completionProvider.ts
@@ -8,7 +8,7 @@ import { URI } from 'vscode-uri';
 import {
 	$DIRPATH, $DLLFUNC, $FILEPATH, ANY, AhkSymbol, ClassNode, FuncNode, Maybe, Property, STRING, SemanticTokenTypes, Token, Variable,
 	a_vars, ahkuris, ahkvars, allIdentifierChar, completionItemCache, completionitem,
-	decltype_expr, dllcalltpe, extsettings, find_class, find_symbol, find_symbols, get_detail,
+	decltype_expr, dllcalltpe, ahklsConfig, find_class, find_symbol, find_symbols, get_detail,
 	generate_fn_comment, get_callinfo, get_class_constructor, get_class_member, get_class_members,
 	lexers, libfuncs, make_search_re, sendAhkRequest, utils, winapis
 } from './common';
@@ -77,7 +77,7 @@ export async function completionProvider(params: CompletionParams, _token: Cance
 	}
 	//#endregion
 
-	const commitCharacters = Object.fromEntries(Object.entries(extsettings.CompletionCommitCharacters ?? {})
+	const commitCharacters = Object.fromEntries(Object.entries(ahklsConfig.CompletionCommitCharacters ?? {})
 		// eslint-disable-next-line @typescript-eslint/no-explicit-any
 		.map((v: any) => (v[1] = (v[1] || undefined)?.split(''), v)));
 	// eslint-disable-next-line prefer-const
@@ -499,7 +499,7 @@ export async function completionProvider(params: CompletionParams, _token: Cance
 	}
 
 	let right_is_paren = '(['.includes(linetext[range.end.character] || '\0');
-	const join_c = extsettings.FormatOptions.brace_style === 0 ? '\n' : ' ';
+	const join_c = ahklsConfig.FormatOptions.brace_style === 0 ? '\n' : ' ';
 
 	// fn|()=>...
 	if (symbol) {
@@ -622,7 +622,7 @@ export async function completionProvider(params: CompletionParams, _token: Cance
 	}
 
 	// keyword
-	const keyword_start_with_uppercase = extsettings.FormatOptions?.keyword_start_with_uppercase;
+	const keyword_start_with_uppercase = ahklsConfig.FormatOptions?.keyword_start_with_uppercase;
 	const addkeyword = keyword_start_with_uppercase ? function (it: CompletionItem) {
 		items.push(it = Object.assign({}, it));
 		it.insertText = (it.insertText ?? it.label).replace(/(?<=^(loop\s)?)[a-z]/g, m => m.toUpperCase());
@@ -637,7 +637,7 @@ export async function completionProvider(params: CompletionParams, _token: Cance
 		let uppercase = (s: string) => s, remove_indent = uppercase;
 		if (keyword_start_with_uppercase)
 			uppercase = (s: string) => s.replace(/\b[a-z](?=\w)/g, m => m.toUpperCase());
-		if (extsettings.FormatOptions?.switch_case_alignment)
+		if (ahklsConfig.FormatOptions?.switch_case_alignment)
 			remove_indent = (s: string) => s.replace(/^\t/gm, '');
 		for (const [label, arr] of [
 			['switch', ['switch ${1:[SwitchValue, CaseSense]}', remove_indent('{\n\tcase ${2:}:\n\t\t${3:}\n\tdefault:\n\t\t$0\n}')]],
@@ -687,15 +687,15 @@ export async function completionProvider(params: CompletionParams, _token: Cance
 	}
 
 	// auto-include
-	if (extsettings.AutoLibInclude) {
+	if (ahklsConfig.AutoLibInclude) {
 		const libdirs = doc.libdirs, caches: Record<string, TextEdit[]> = {};
 		let exportnum = 0, line = -1, first_is_comment: boolean | undefined, cm: Token;
 		let dir = doc.workspaceFolder;
 		dir = (dir ? URI.parse(dir).fsPath : doc.scriptdir).toLowerCase();
 		doc.includedir.forEach((v, k) => line = k);
 		for (const u in libfuncs) {
-			if (!list[u] && (path = libfuncs[u].fsPath) && ((extsettings.AutoLibInclude > 1 && libfuncs[u].islib) ||
-				((extsettings.AutoLibInclude & 1) && path.toLowerCase().startsWith(dir)))) {
+			if (!list[u] && (path = libfuncs[u].fsPath) && ((ahklsConfig.AutoLibInclude > 1 && libfuncs[u].islib) ||
+				((ahklsConfig.AutoLibInclude & 1) && path.toLowerCase().startsWith(dir)))) {
 				for (const it of libfuncs[u]) {
 					expg.test(l = it.name) && (vars[l.toUpperCase()] ??= (
 						cpitem = convertNodeCompletion(it), exportnum++,
@@ -924,7 +924,7 @@ export async function completionProvider(params: CompletionParams, _token: Cance
 			// fall through
 			case SymbolKind.Function:
 				ci.kind = info.kind === SymbolKind.Method ? CompletionItemKind.Method : CompletionItemKind.Function;
-				if (extsettings.CompleteFunctionParens) {
+				if (ahklsConfig.CompleteFunctionParens) {
 					const fn = info as FuncNode;
 					if (right_is_paren)
 						ci.command = { title: 'cursorRight', command: 'cursorRight' };

--- a/server/src/completionProvider.ts
+++ b/server/src/completionProvider.ts
@@ -8,10 +8,11 @@ import { URI } from 'vscode-uri';
 import {
 	$DIRPATH, $DLLFUNC, $FILEPATH, ANY, AhkSymbol, ClassNode, FuncNode, Maybe, Property, STRING, SemanticTokenTypes, Token, Variable,
 	a_vars, ahkuris, ahkvars, allIdentifierChar, completionItemCache, completionitem,
-	decltype_expr, dllcalltpe, ahklsConfig, find_class, find_symbol, find_symbols, get_detail,
+	decltype_expr, dllcalltpe, find_class, find_symbol, find_symbols, get_detail,
 	generate_fn_comment, get_callinfo, get_class_constructor, get_class_member, get_class_members,
 	lexers, libfuncs, make_search_re, sendAhkRequest, utils, winapis
 } from './common';
+import { ahklsConfig } from '../../util/src/config';
 
 export async function completionProvider(params: CompletionParams, _token: CancellationToken): Promise<Maybe<CompletionItem[]>> {
 	let { position, textDocument: { uri } } = params;

--- a/server/src/formattingProvider.ts
+++ b/server/src/formattingProvider.ts
@@ -1,5 +1,6 @@
 import { DocumentFormattingParams, DocumentOnTypeFormattingParams, DocumentRangeFormattingParams, Position, Range, TextEdit } from 'vscode-languageserver';
-import { chinese_punctuations, ahklsConfig, lexers, Token } from './common';
+import { chinese_punctuations, lexers, Token } from './common';
+import { ahklsConfig } from '../../util/src/config';
 
 export async function documentFormatting(params: DocumentFormattingParams): Promise<TextEdit[]> {
 	const doc = lexers[params.textDocument.uri.toLowerCase()], range = Range.create(0, 0, doc.document.lineCount, 0);

--- a/server/src/formattingProvider.ts
+++ b/server/src/formattingProvider.ts
@@ -1,9 +1,9 @@
 import { DocumentFormattingParams, DocumentOnTypeFormattingParams, DocumentRangeFormattingParams, Position, Range, TextEdit } from 'vscode-languageserver';
-import { chinese_punctuations, extsettings, lexers, Token } from './common';
+import { chinese_punctuations, ahklsConfig, lexers, Token } from './common';
 
 export async function documentFormatting(params: DocumentFormattingParams): Promise<TextEdit[]> {
 	const doc = lexers[params.textDocument.uri.toLowerCase()], range = Range.create(0, 0, doc.document.lineCount, 0);
-	const opts = { ...extsettings.FormatOptions };
+	const opts = { ...ahklsConfig.FormatOptions };
 	opts.indent_string ??= params.options.insertSpaces ? ' '.repeat(params.options.tabSize) : '\t';
 	const newText = doc.beautify(opts);
 	return [{ range, newText }];
@@ -11,7 +11,7 @@ export async function documentFormatting(params: DocumentFormattingParams): Prom
 
 export async function rangeFormatting(params: DocumentRangeFormattingParams): Promise<TextEdit[] | undefined> {
 	const doc = lexers[params.textDocument.uri.toLowerCase()], range = params.range;
-	const opts = { ...extsettings.FormatOptions };
+	const opts = { ...ahklsConfig.FormatOptions };
 	opts.indent_string = params.options.insertSpaces ? ' '.repeat(params.options.tabSize) : '\t';
 	const newText = doc.beautify(opts, range).trim();
 	return [{ range, newText }];
@@ -19,7 +19,7 @@ export async function rangeFormatting(params: DocumentRangeFormattingParams): Pr
 
 export async function typeFormatting(params: DocumentOnTypeFormattingParams): Promise<TextEdit[] | undefined> {
 	const doc = lexers[params.textDocument.uri.toLowerCase()], { ch, position } = params;
-	const opts = { ...extsettings.FormatOptions };
+	const opts = { ...ahklsConfig.FormatOptions };
 	let tk: Token, s: string, pp: number | undefined, result: TextEdit[] | undefined;
 	opts.indent_string = ' '.repeat(params.options.tabSize);
 	s = doc.document.getText({ start: { line: 0, character: 0 }, end: { line: 0, character: 1 } });

--- a/server/src/semanticTokensProvider.ts
+++ b/server/src/semanticTokensProvider.ts
@@ -1,8 +1,9 @@
 import { CancellationToken, DocumentSymbol, Range, SemanticTokens, SemanticTokensParams, SemanticTokensRangeParams, SymbolKind } from 'vscode-languageserver';
 import {
 	ASSIGN_TYPE, AhkSymbol, ClassNode, FuncNode, Lexer, Property, SemanticToken, SemanticTokenModifiers, SemanticTokenTypes, Token, Variable,
-	checkParams, diagnostic, ahklsConfig, get_class_member, get_class_members, globalsymbolcache, lexers, symbolProvider
+	checkParams, diagnostic, get_class_member, get_class_members, globalsymbolcache, lexers, symbolProvider
 } from './common';
+import { ahklsConfig } from '../../util/src/config';
 
 let curclass: ClassNode | undefined;
 const memscache = new Map<ClassNode, Record<string, AhkSymbol>>();

--- a/server/src/semanticTokensProvider.ts
+++ b/server/src/semanticTokensProvider.ts
@@ -1,7 +1,7 @@
 import { CancellationToken, DocumentSymbol, Range, SemanticTokens, SemanticTokensParams, SemanticTokensRangeParams, SymbolKind } from 'vscode-languageserver';
 import {
 	ASSIGN_TYPE, AhkSymbol, ClassNode, FuncNode, Lexer, Property, SemanticToken, SemanticTokenModifiers, SemanticTokenTypes, Token, Variable,
-	checkParams, diagnostic, extsettings, get_class_member, get_class_members, globalsymbolcache, lexers, symbolProvider
+	checkParams, diagnostic, ahklsConfig, get_class_member, get_class_members, globalsymbolcache, lexers, symbolProvider
 } from './common';
 
 let curclass: ClassNode | undefined;
@@ -123,7 +123,7 @@ function resolveSemanticType(name: string, tk: Token, doc: Lexer) {
 						return sem.type = SemanticTokenTypes.property;
 					}
 					case undefined:
-						if ((curclass.checkmember ?? doc.checkmember) !== false && extsettings.Diagnostics.ClassNonDynamicMemberCheck) {
+						if ((curclass.checkmember ?? doc.checkmember) !== false && ahklsConfig.Diagnostics.ClassNonDynamicMemberCheck) {
 							const tt = doc.tokens[tk.next_token_offset];
 							if (ASSIGN_TYPE.includes(tt?.content)) {
 								cls_add_prop(curclass, tk.content, tk.offset);

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -14,7 +14,7 @@ import {
 	parse_include, prepareRename, rangeFormatting, read_ahk_file, referenceProvider, renameProvider, SemanticTokenModifiers,
 	semanticTokensOnFull, semanticTokensOnRange, SemanticTokenTypes, set_ahk_h, set_ahkpath, set_Connection,
 	set_dirname, set_locale, set_version, set_WorkspaceFolders, setting, signatureProvider, sleep, symbolProvider,
-	traverse_include, typeFormatting, update_settings, utils, winapis, workspaceSymbolProvider
+	traverse_include, typeFormatting, updateConfig, utils, winapis, workspaceSymbolProvider
 } from './common';
 import { PEFile, RESOURCE_TYPE, searchAndOpenPEFile } from './PEFile';
 import { resolvePath, runscript } from './scriptrunner';
@@ -97,7 +97,7 @@ connection.onInitialize(async params => {
 	loadlocalize();
 	initahk2cache();
 	if (configs)
-		update_settings(configs);
+		updateConfig(configs);
 	if (!(await setInterpreter(resolvePath(ahklsConfig.InterpreterPath ??= ''))))
 		patherr(setting.ahkpatherr());
 	set_WorkspaceFolders(workspaceFolders);
@@ -130,7 +130,7 @@ connection.onDidChangeConfiguration(async change => {
 		return;
 	}
 	const { AutoLibInclude, InterpreterPath, Syntaxes } = ahklsConfig;
-	update_settings(newset);
+	updateConfig(newset);
 	set_WorkspaceFolders(workspaceFolders);
 	if (InterpreterPath !== ahklsConfig.InterpreterPath) {
 		if (await setInterpreter(resolvePath(ahklsConfig.InterpreterPath ??= '')))

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -18,7 +18,7 @@ import {
 } from './common';
 import { PEFile, RESOURCE_TYPE, searchAndOpenPEFile } from './PEFile';
 import { resolvePath, runscript } from './scriptrunner';
-import { AHKLSSettings, configPrefix } from '../../util/src/config';
+import { AHKLSConfig, configPrefix } from '../../util/src/config';
 
 const languageServer = 'ahk2-language-server';
 const documents = new TextDocuments(TextDocument);
@@ -83,7 +83,7 @@ connection.onInitialize(async params => {
 		result.capabilities.workspace = { workspaceFolders: { supported: true } };
 	}
 
-	let configs: AHKLSSettings | undefined;
+	let configs: AHKLSConfig | undefined;
 	const env = process.env;
 	if (env.AHK2_LS_CONFIG)
 		try { configs = JSON.parse(env.AHK2_LS_CONFIG); } catch { }
@@ -122,7 +122,7 @@ connection.onInitialized(() => {
 });
 
 connection.onDidChangeConfiguration(async change => {
-	let newset: AHKLSSettings | undefined = change?.settings;
+	let newset: AHKLSConfig | undefined = change?.settings;
 	if (hasConfigurationCapability && !newset)
 		newset = await connection.workspace.getConfiguration(configPrefix);
 	if (!newset) {

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -7,7 +7,7 @@ import {
 import { URI } from 'vscode-uri';
 import { get_ahkProvider } from './ahkProvider';
 import {
-	a_vars, AHKLSSettings, ahkpath_cur, builtin_variable, builtin_variable_h, chinese_punctuations, clearLibfuns, codeActionProvider,
+	a_vars, ahkpath_cur, builtin_variable, builtin_variable_h, chinese_punctuations, clearLibfuns, codeActionProvider,
 	colorPresentation, colorProvider, commands, completionProvider, defintionProvider,
 	documentFormatting, enum_ahkfiles, executeCommandProvider, exportSymbols, extsettings, getVersionInfo, hoverProvider,
 	initahk2cache, isahk2_h, Lexer, lexers, libdirs, libfuncs, loadahk2, loadlocalize, openFile,
@@ -18,6 +18,7 @@ import {
 } from './common';
 import { PEFile, RESOURCE_TYPE, searchAndOpenPEFile } from './PEFile';
 import { resolvePath, runscript } from './scriptrunner';
+import { AHKLSSettings, configPrefix } from '../../util/src/config';
 
 const languageServer = 'ahk2-language-server';
 const documents = new TextDocuments(TextDocument);
@@ -123,7 +124,7 @@ connection.onInitialized(() => {
 connection.onDidChangeConfiguration(async change => {
 	let newset: AHKLSSettings | undefined = change?.settings;
 	if (hasConfigurationCapability && !newset)
-		newset = await connection.workspace.getConfiguration('AutoHotkey2');
+		newset = await connection.workspace.getConfiguration(configPrefix);
 	if (!newset) {
 		connection.window.showWarningMessage('Failed to obtain the configuration');
 		return;

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -9,7 +9,7 @@ import { get_ahkProvider } from './ahkProvider';
 import {
 	a_vars, ahkpath_cur, builtin_variable, builtin_variable_h, chinese_punctuations, clearLibfuns, codeActionProvider,
 	colorPresentation, colorProvider, commands, completionProvider, defintionProvider,
-	documentFormatting, enum_ahkfiles, executeCommandProvider, exportSymbols, ahklsConfig, getVersionInfo, hoverProvider,
+	documentFormatting, enum_ahkfiles, executeCommandProvider, exportSymbols, getVersionInfo, hoverProvider,
 	initahk2cache, isahk2_h, Lexer, lexers, libdirs, libfuncs, loadahk2, loadlocalize, openFile,
 	parse_include, prepareRename, rangeFormatting, read_ahk_file, referenceProvider, renameProvider, SemanticTokenModifiers,
 	semanticTokensOnFull, semanticTokensOnRange, SemanticTokenTypes, set_ahk_h, set_ahkpath, set_Connection,
@@ -18,7 +18,7 @@ import {
 } from './common';
 import { PEFile, RESOURCE_TYPE, searchAndOpenPEFile } from './PEFile';
 import { resolvePath, runscript } from './scriptrunner';
-import { AHKLSConfig, CfgKey, configPrefix, getCfg } from '../../util/src/config';
+import { AHKLSConfig, CfgKey, configPrefix, getCfg, ahklsConfig } from '../../util/src/config';
 
 const languageServer = 'ahk2-language-server';
 const documents = new TextDocuments(TextDocument);

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -83,21 +83,21 @@ connection.onInitialize(async params => {
 		result.capabilities.workspace = { workspaceFolders: { supported: true } };
 	}
 
-	let configs: AHKLSConfig | undefined;
+	let initialConfig: AHKLSConfig | undefined;
 	const env = process.env;
 	if (env.AHK2_LS_CONFIG)
-		try { configs = JSON.parse(env.AHK2_LS_CONFIG); } catch { }
+		try { initialConfig = JSON.parse(env.AHK2_LS_CONFIG); } catch { }
 	if (params.initializationOptions)
-		configs = Object.assign(configs ?? {}, params.initializationOptions);
+		initialConfig = Object.assign(initialConfig ?? {}, params.initializationOptions);
 	set_dirname(resolve(__dirname, '../..'));
-	set_locale((configs ? getCfg(configs, CfgKey.Locale) : undefined) ?? params.locale);
+	set_locale((initialConfig ? getCfg(CfgKey.Locale, initialConfig) : undefined) ?? params.locale);
 	utils.get_RCDATA = getRCDATA;
 	utils.get_DllExport = getDllExport;
 	utils.get_ahkProvider = get_ahkProvider;
 	loadlocalize();
 	initahk2cache();
-	if (configs)
-		updateConfig(configs);
+	if (initialConfig)
+		updateConfig(initialConfig);
 	if (!(await setInterpreter(resolvePath(ahklsConfig.InterpreterPath ??= ''))))
 		patherr(setting.ahkpatherr());
 	set_WorkspaceFolders(workspaceFolders);
@@ -214,7 +214,7 @@ documents.listen(connection);
 connection.listen();
 
 async function patherr(msg: string) {
-	if (!getCfg(ahklsConfig, CfgKey.Commands)?.includes('ahk2.executeCommand'))
+	if (!getCfg(CfgKey.Commands)?.includes('ahk2.executeCommand'))
 		return connection.window.showErrorMessage(msg);
 	if (await connection.window.showErrorMessage(msg, { title: 'Select Interpreter' }))
 		connection.sendRequest('ahk2.executeCommand', ['ahk2.set.interpreter']);

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -7,7 +7,7 @@ import {
 import { URI } from 'vscode-uri';
 import { get_ahkProvider } from './ahkProvider';
 import {
-	a_vars, AHKLSSettings, ahkpath_cur, builtin_variable, builtin_variable_h, chinese_punctuations, clearLibfuns, codeActionProvider,
+	a_vars, ahkpath_cur, builtin_variable, builtin_variable_h, chinese_punctuations, clearLibfuns, codeActionProvider,
 	colorPresentation, colorProvider, commands, completionProvider, defintionProvider,
 	documentFormatting, enum_ahkfiles, executeCommandProvider, exportSymbols, extsettings, getVersionInfo, hoverProvider,
 	initahk2cache, isahk2_h, Lexer, lexers, libdirs, libfuncs, loadahk2, loadlocalize, openFile,
@@ -18,6 +18,7 @@ import {
 } from './common';
 import { PEFile, RESOURCE_TYPE, searchAndOpenPEFile } from './PEFile';
 import { resolvePath, runscript } from './scriptrunner';
+import { AHKLSSettings } from '../../util/src/config';
 
 const languageServer = 'ahk2-language-server';
 const documents = new TextDocuments(TextDocument);

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -18,7 +18,7 @@ import {
 } from './common';
 import { PEFile, RESOURCE_TYPE, searchAndOpenPEFile } from './PEFile';
 import { resolvePath, runscript } from './scriptrunner';
-import { AHKLSSettings } from '../../util/src/config';
+import { AHKLSSettings, configPrefix } from '../../util/src/config';
 
 const languageServer = 'ahk2-language-server';
 const documents = new TextDocuments(TextDocument);
@@ -124,7 +124,7 @@ connection.onInitialized(() => {
 connection.onDidChangeConfiguration(async change => {
 	let newset: AHKLSSettings | undefined = change?.settings;
 	if (hasConfigurationCapability && !newset)
-		newset = await connection.workspace.getConfiguration('AutoHotkey2');
+		newset = await connection.workspace.getConfiguration(configPrefix);
 	if (!newset) {
 		connection.window.showWarningMessage('Failed to obtain the configuration');
 		return;

--- a/server/src/symbolProvider.ts
+++ b/server/src/symbolProvider.ts
@@ -8,9 +8,10 @@ import {
 	ANY, AhkSymbol, CallSite, ClassNode, FuncNode, FuncScope, Lexer, Property, SUPER, SemanticToken,
 	SemanticTokenModifiers, SemanticTokenTypes, THIS, Token, VARREF, Variable,
 	ahkuris, ahkvars, check_same_name_error, connection, decltype_expr,
-	diagnostic, enum_ahkfiles, ahklsConfig, find_class, get_class_constructor,
+	diagnostic, enum_ahkfiles, find_class, get_class_constructor,
 	is_line_continue, lexers, make_same_name_error, openFile, warn, workspaceFolders
 } from './common';
+import { ahklsConfig } from '../../util/src/config';
 
 export let globalsymbolcache: Record<string, AhkSymbol> = {};
 

--- a/server/src/symbolProvider.ts
+++ b/server/src/symbolProvider.ts
@@ -8,7 +8,7 @@ import {
 	ANY, AhkSymbol, CallSite, ClassNode, FuncNode, FuncScope, Lexer, Property, SUPER, SemanticToken,
 	SemanticTokenModifiers, SemanticTokenTypes, THIS, Token, VARREF, Variable,
 	ahkuris, ahkvars, check_same_name_error, connection, decltype_expr,
-	diagnostic, enum_ahkfiles, extsettings, find_class, get_class_constructor,
+	diagnostic, enum_ahkfiles, ahklsConfig, find_class, get_class_constructor,
 	is_line_continue, lexers, make_same_name_error, openFile, warn, workspaceFolders
 } from './common';
 
@@ -40,7 +40,7 @@ export function symbolProvider(params: DocumentSymbolParams, token?: Cancellatio
 		return doc.symbolInformation;
 	if (ahkuris.winapi && !list.includes(ahkuris.winapi))
 		winapis = lexers[ahkuris.winapi]?.declaration ?? winapis;
-	const warnLocalSameAsGlobal = extsettings.Warn?.LocalSameAsGlobal;
+	const warnLocalSameAsGlobal = ahklsConfig.Warn?.LocalSameAsGlobal;
 	const result: AhkSymbol[] = [], unset_vars = new Map<Variable, Variable>();
 	const filter_types: SymbolKind[] = [SymbolKind.Method, SymbolKind.Property, SymbolKind.Class];
 	for (const [k, v] of Object.entries(doc.declaration)) {
@@ -54,7 +54,7 @@ export function symbolProvider(params: DocumentSymbolParams, token?: Cancellatio
 			result.push(v), converttype(v, v, islib || v === ahkvars[k]).definition = v;
 	}
 	flatTree(doc);
-	if (extsettings.Warn?.VarUnset)
+	if (ahklsConfig.Warn?.VarUnset)
 		for (const [k, v] of unset_vars) {
 			if (k.assigned)
 				continue;
@@ -293,7 +293,7 @@ function get_func_param_count(fn: FuncNode) {
 export function checkParams(doc: Lexer, node: FuncNode, info: CallSite) {
 	const paraminfo = info.paraminfo;
 	let is_cls: boolean, params;
-	if (!paraminfo || !extsettings.Diagnostics.ParamsCheck) return;
+	if (!paraminfo || !ahklsConfig.Diagnostics.ParamsCheck) return;
 	if ((is_cls = node?.kind === SymbolKind.Class))
 		node = get_class_constructor(node as unknown as ClassNode) as FuncNode;
 	if (!(params = node?.params)) return;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,5 +7,5 @@
 		"noEmit": true,
 		"strict": true
 	},
-	"include": ["client/src", "server/src"]
+	"include": ["client/src", "server/src", "util/src"]
 }

--- a/util/src/config.spec.ts
+++ b/util/src/config.spec.ts
@@ -1,0 +1,21 @@
+import * as assert from 'assert';
+import { suite, test } from 'mocha';
+import { AHKLSConfig, CfgKey, FormatOptions, getCfg, LibIncludeType, setCfg } from './config';
+
+suite('setCfg', () => {
+	test('top-level property', () => {
+		const cfg: AHKLSConfig = { AutoLibInclude: LibIncludeType.All } as AHKLSConfig;
+
+		setCfg(CfgKey.LibrarySuggestions, LibIncludeType.Disabled, cfg);
+
+		assert.strictEqual(LibIncludeType.Disabled, getCfg(CfgKey.LibrarySuggestions, cfg));
+	});
+
+	test('nested property', () => {
+		const cfg: AHKLSConfig = { FormatOptions: { brace_style: 1 } } as AHKLSConfig;
+
+		setCfg(CfgKey.Formatter, { brace_style: 2 }, cfg);
+
+		assert.strictEqual(2, getCfg<FormatOptions>(CfgKey.Formatter, cfg).brace_style);
+	});
+});

--- a/util/src/config.ts
+++ b/util/src/config.ts
@@ -53,7 +53,7 @@ export interface FormatOptions {
 	wrap_line_length?: number
 }
 
-/** Matches the contributed extension configuration */
+/** Matches the contributed extension configuration in package.json */
 export interface AHKLSConfig {
 	locale?: string
 	commands?: string[]
@@ -87,6 +87,11 @@ export interface AHKLSConfig {
 	WorkingDirs: string[]
 }
 
+/**
+ * The global object shared across the server.
+ * The client fetches the config from VS Code directly.
+ * Updated when the user changes their settings.
+ */
 export const ahklsConfig: AHKLSConfig = {
 	ActionWhenV1IsDetected: 'Warn',
 	AutoLibInclude: 0,
@@ -129,4 +134,15 @@ export const getCfg = <T = string>(key: CfgKey, config: AHKLSConfig = ahklsConfi
 		value = value[k];
 	}
 	return value;
+};
+
+export const setCfg = (key: CfgKey, value: unknown, config: AHKLSConfig = ahklsConfig): void => {
+	const keyPath = key.split('.');
+	// ConfigKey values are guaranteed to work ;)
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
+	let obj: any = config;
+	for (const k of keyPath.slice(0, -1)) {
+		obj = obj[k];
+	}
+	obj[keyPath[keyPath.length - 1]] = value;
 };

--- a/util/src/config.ts
+++ b/util/src/config.ts
@@ -1,0 +1,91 @@
+//* Utility functions to access the config variable from either client or server
+export enum CfgKey {	
+	ActionWhenV1Detected = 'ActionWhenV1IsDetected',
+	CallWithoutParentheses = 'Warn.CallWithoutParentheses',
+	ClassNonDynamicMemberCheck = 'Diagnostics.ClassNonDynamicMemberCheck',
+	Commands = 'commands',
+	CommentTagRegex = 'CommentTags',
+	CompleteFunctionCalls = 'CompleteFunctionParens',
+	CompletionCommitCharacters = 'CompletionCommitCharacters',
+	Exclude = 'Files.Exclude',
+	ExtensionUri = 'extensionUri',
+	Formatter = 'FormatOptions',
+	InterpreterPath = 'InterpreterPath',
+	LibrarySuggestions = 'AutoLibInclude',
+	LocalSameAsGlobal = 'Warn.LocalSameAsGlobal',
+	Locale = 'locale',
+	MaxScanDepth = 'Files.ScanMaxDepth',
+	ParamsCheck = 'Diagnostics.ParamsCheck',
+	SymbolFoldingFromOpenBrace = 'SymbolFoldingFromOpenBrace',
+	Syntaxes = 'Syntaxes',
+	VarUnset = 'Warn.varUnset',
+	WorkingDirectories = 'WorkingDirs',
+}
+
+export type ActionType = 'Continue' | 'Warn' | 'SkipLine' | 'SwitchToV1' | 'Stop';
+
+export enum LibIncludeType {
+	'Disabled',
+	'Local',
+	'User and Standard',
+	'All'
+}
+
+export interface FormatOptions {
+	array_style?: number
+	brace_style?: number
+	break_chained_methods?: boolean
+	ignore_comment?: boolean
+	indent_string?: string
+	indent_between_hotif_directive?: boolean
+	keyword_start_with_uppercase?: boolean
+	max_preserve_newlines?: number
+	object_style?: number
+	preserve_newlines?: boolean
+	space_before_conditional?: boolean
+	space_after_double_colon?: boolean
+	space_in_empty_paren?: boolean
+	space_in_other?: boolean
+	space_in_paren?: boolean
+	switch_case_alignment?: boolean
+	symbol_with_same_case?: boolean
+	white_space_before_inline_comment?: string
+	wrap_line_length?: number
+}
+
+/** Matches the contributed extension configuration */
+export interface AHKLSSettings {
+	locale?: string
+	commands?: string[]
+	extensionUri?: string
+	ActionWhenV1IsDetected: ActionType
+	AutoLibInclude: LibIncludeType
+	CommentTags?: string
+	CompleteFunctionParens: boolean
+	CompletionCommitCharacters?: {
+		Class: string
+		Function: string
+	}
+	Diagnostics: {
+		ClassNonDynamicMemberCheck: boolean
+		ParamsCheck: boolean
+	}
+	Files: {
+		Exclude: string[]
+		MaxDepth: number
+	}
+	FormatOptions: FormatOptions
+	InterpreterPath: string
+	GlobalStorage?: string
+	Syntaxes?: string
+	SymbolFoldingFromOpenBrace: boolean
+	Warn: {
+		VarUnset: boolean
+		LocalSameAsGlobal: boolean
+		CallWithoutParentheses: boolean | /* Parentheses */ 1
+	}
+	WorkingDirs: string[]
+}
+
+/** The start of each config value in package.json */
+export const configPrefix = 'AutoHotkey2';

--- a/util/src/config.ts
+++ b/util/src/config.ts
@@ -89,3 +89,16 @@ export interface AHKLSConfig {
 
 /** The start of each config value in package.json */
 export const configPrefix = 'AutoHotkey2';
+
+
+/** Gets a single config value from the given config */
+export const getCfg = <T = string>(config: AHKLSConfig, key: CfgKey): T => {
+	const keyPath = key.split('.');
+	// ConfigKey values are guaranteed to work ;)
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
+	let value: any = config;
+	for (const k of keyPath) {
+		value = value[k];
+	}
+	return value;
+};

--- a/util/src/config.ts
+++ b/util/src/config.ts
@@ -54,7 +54,7 @@ export interface FormatOptions {
 }
 
 /** Matches the contributed extension configuration */
-export interface AHKLSSettings {
+export interface AHKLSConfig {
 	locale?: string
 	commands?: string[]
 	extensionUri?: string

--- a/util/src/config.ts
+++ b/util/src/config.ts
@@ -3,14 +3,17 @@ export enum CfgKey {
 	ActionWhenV1Detected = 'ActionWhenV1IsDetected',
 	CallWithoutParentheses = 'Warn.CallWithoutParentheses',
 	ClassNonDynamicMemberCheck = 'Diagnostics.ClassNonDynamicMemberCheck',
+	Commands = 'commands',
 	CommentTagRegex = 'CommentTags',
 	CompleteFunctionCalls = 'CompleteFunctionParens',
 	CompletionCommitCharacters = 'CompletionCommitCharacters',
 	Exclude = 'Files.Exclude',
+	ExtensionUri = 'extensionUri',
 	Formatter = 'FormatOptions',
 	InterpreterPath = 'InterpreterPath',
 	LibrarySuggestions = 'AutoLibInclude',
 	LocalSameAsGlobal = 'Warn.LocalSameAsGlobal',
+	Locale = 'locale',
 	MaxScanDepth = 'Files.ScanMaxDepth',
 	ParamsCheck = 'Diagnostics.ParamsCheck',
 	SymbolFoldingFromOpenBrace = 'SymbolFoldingFromOpenBrace',
@@ -50,6 +53,7 @@ export interface FormatOptions {
 	wrap_line_length?: number
 }
 
+/** Matches the contributed extension configuration */
 export interface AHKLSSettings {
 	locale?: string
 	commands?: string[]
@@ -82,3 +86,6 @@ export interface AHKLSSettings {
 	}
 	WorkingDirs: string[]
 }
+
+/** The start of each config value in package.json */
+export const configPrefix = 'AutoHotkey2';

--- a/util/src/config.ts
+++ b/util/src/config.ts
@@ -1,0 +1,84 @@
+//* Utility functions to access the config variable from either client or server
+export enum CfgKey {	
+	ActionWhenV1Detected = 'ActionWhenV1IsDetected',
+	CallWithoutParentheses = 'Warn.CallWithoutParentheses',
+	ClassNonDynamicMemberCheck = 'Diagnostics.ClassNonDynamicMemberCheck',
+	CommentTagRegex = 'CommentTags',
+	CompleteFunctionCalls = 'CompleteFunctionParens',
+	CompletionCommitCharacters = 'CompletionCommitCharacters',
+	Exclude = 'Files.Exclude',
+	Formatter = 'FormatOptions',
+	InterpreterPath = 'InterpreterPath',
+	LibrarySuggestions = 'AutoLibInclude',
+	LocalSameAsGlobal = 'Warn.LocalSameAsGlobal',
+	MaxScanDepth = 'Files.ScanMaxDepth',
+	ParamsCheck = 'Diagnostics.ParamsCheck',
+	SymbolFoldingFromOpenBrace = 'SymbolFoldingFromOpenBrace',
+	Syntaxes = 'Syntaxes',
+	VarUnset = 'Warn.varUnset',
+	WorkingDirectories = 'WorkingDirs',
+}
+
+export type ActionType = 'Continue' | 'Warn' | 'SkipLine' | 'SwitchToV1' | 'Stop';
+
+export enum LibIncludeType {
+	'Disabled',
+	'Local',
+	'User and Standard',
+	'All'
+}
+
+export interface FormatOptions {
+	array_style?: number
+	brace_style?: number
+	break_chained_methods?: boolean
+	ignore_comment?: boolean
+	indent_string?: string
+	indent_between_hotif_directive?: boolean
+	keyword_start_with_uppercase?: boolean
+	max_preserve_newlines?: number
+	object_style?: number
+	preserve_newlines?: boolean
+	space_before_conditional?: boolean
+	space_after_double_colon?: boolean
+	space_in_empty_paren?: boolean
+	space_in_other?: boolean
+	space_in_paren?: boolean
+	switch_case_alignment?: boolean
+	symbol_with_same_case?: boolean
+	white_space_before_inline_comment?: string
+	wrap_line_length?: number
+}
+
+export interface AHKLSSettings {
+	locale?: string
+	commands?: string[]
+	extensionUri?: string
+	ActionWhenV1IsDetected: ActionType
+	AutoLibInclude: LibIncludeType
+	CommentTags?: string
+	CompleteFunctionParens: boolean
+	CompletionCommitCharacters?: {
+		Class: string
+		Function: string
+	}
+	Diagnostics: {
+		ClassNonDynamicMemberCheck: boolean
+		ParamsCheck: boolean
+	}
+	Files: {
+		Exclude: string[]
+		MaxDepth: number
+	}
+	FormatOptions: FormatOptions
+	InterpreterPath: string
+	GlobalStorage?: string
+	Syntaxes?: string
+	SymbolFoldingFromOpenBrace: boolean
+	Warn: {
+		VarUnset: boolean
+		LocalSameAsGlobal: boolean
+		CallWithoutParentheses: boolean | /* Parentheses */ 1
+	}
+	WorkingDirs: string[]
+}

--- a/util/src/config.ts
+++ b/util/src/config.ts
@@ -120,7 +120,7 @@ export const configPrefix = 'AutoHotkey2';
 
 
 /** Gets a single config value from the given config */
-export const getCfg = <T = string>(config: AHKLSConfig, key: CfgKey): T => {
+export const getCfg = <T = string>(key: CfgKey, config: AHKLSConfig = ahklsConfig): T => {
 	const keyPath = key.split('.');
 	// ConfigKey values are guaranteed to work ;)
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/util/src/config.ts
+++ b/util/src/config.ts
@@ -87,6 +87,34 @@ export interface AHKLSConfig {
 	WorkingDirs: string[]
 }
 
+export const ahklsConfig: AHKLSConfig = {
+	ActionWhenV1IsDetected: 'Warn',
+	AutoLibInclude: 0,
+	CommentTags: '^;;\\s*(.*)',
+	CompleteFunctionParens: false,
+	CompletionCommitCharacters: {
+		Class: '.(',
+		Function: '('
+	},
+	Diagnostics: {
+		ClassNonDynamicMemberCheck: true,
+		ParamsCheck: true
+	},
+	Files: {
+		Exclude: [],
+		MaxDepth: 2
+	},
+	FormatOptions: {},
+	InterpreterPath: 'C:\\Program Files\\AutoHotkey\\v2\\AutoHotkey.exe',
+	SymbolFoldingFromOpenBrace: false,
+	Warn: {
+		VarUnset: true,
+		LocalSameAsGlobal: false,
+		CallWithoutParentheses: false
+	},
+	WorkingDirs: []
+};
+
 /** The start of each config value in package.json */
 export const configPrefix = 'AutoHotkey2';
 


### PR DESCRIPTION
Current tests require building the project and opening VS Code, but many functions can be tested without that. Unit tests just require compiling TS and allow for better reporting of code coverage and diagnosing issues faster.

We could probably build with esbuild instead of tsc, but for now tsc is fine.

This builds off #611 