### PR TITLE
docs(d.ahk): add missing 'L' attribute to FileGetAttrib JSDoc

### DIFF
--- a/syntaxes/ahk2.d.ahk
+++ b/syntaxes/ahk2.d.ahk
@@ -1235,6 +1235,8 @@ FileExist(FilePattern: $FilePath) => String
  * C = COMPRESSED (compressed)
  * 
  * T = TEMPORARY (temporary)
+ * 
+ * L = REPARSE_POINT (typically a symbolic link)
  */
 FileGetAttrib(FileName?: $FilePath) => String
 

--- a/syntaxes/zh-cn/ahk2.d.ahk
+++ b/syntaxes/zh-cn/ahk2.d.ahk
@@ -1229,6 +1229,8 @@ FileExist(FilePattern: $FilePath) => String
  * C = COMPRESSED(压缩)
  * 
  * T = TEMPORARY(临时)
+ * 
+ * L = REPARSE_POINT(通常是符号链接)
  */
 FileGetAttrib(FileName?: $FilePath) => String
 


### PR DESCRIPTION
Added the missing 'L' (REPARSE_POINT / symlink) attribute to the JSDoc documentation for the 'FileGetAttrib' function. Updated both English and Chinese (zh-cn) versions of 'ahk2.d.ahk'.