### PR TITLE
Fix module resolution when `AhkImportPath` is set

### DIFF
--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -199,7 +199,7 @@ s := "$import|" EnvGet("AhkImportPath") "\`n"
 for _, k in ${JSON.stringify([...builtinVars, ...builtinVars_h])}
 	try if SubStr(k, 1, 2) = "a_" && !IsObject(v := %k%)
 		s .= SubStr(k, 3) "|" v "\`n"
-FileOpen(A_ScriptFullPath, "w", "utf-8").Write(s)`;
+FileOpen(A_ScriptFullPath, "w", "utf-8-raw").Write(s)`;
 	return new Promise<void>(r => {
 		server.on('connection', socket => {
 			const destroy = () => socket.destroy();


### PR DESCRIPTION
server.ts:202 uses `FileOpen` to write its output file, which writes a UTF-8 BOM at the start of the file.

https://github.com/thqby/vscode-autohotkey2-lsp/blob/c7a133e1934b16c61ef91f6b3d5ee2c35bb988fc/server/src/server.ts#L202

The contents of the file end up being `\uFEFF$import|<AhkImportPath>...`, which, when read in later on, puts the BOM at the start of `$import's` property name, so everything else that checks for `$import` gets back `undefined`.

Fix is trivial - use `utf-8-raw` when writing the output file to avoid adding a BOM in the first place.